### PR TITLE
Two small enhancements for dealing with large folders

### DIFF
--- a/libsylph/folder.c
+++ b/libsylph/folder.c
@@ -1291,7 +1291,7 @@ gint folder_item_fetch_all_msg(FolderItem *item)
 		gchar *msg;
 
 		num++;
-		if (folder->ui_func)
+		if (folder->ui_func && num % 128 == 0)
 			folder->ui_func(folder, item,
 					folder->ui_func_data ?
 					folder->ui_func_data :

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -2781,6 +2781,7 @@ static gint imap_get_uncached_messages_func(IMAPSession *session, gpointer data)
 		if (sock_getline(SESSION(session)->sock, &tmp) < 0) {
 			log_warning(_("error occurred while getting envelope.\n"));
 			g_string_free(str, TRUE);
+			get_data->newlist = newlist;
 			return IMAP_SOCKET;
 		}
 		strretchomp(tmp);


### PR DESCRIPTION
今日は

I have two small fixes that improve sylpheed when handling large folders.

The first ensures that fetched headers are not discarded when an error occurs.
The second speeds up downloading by not updating the UI for every message,
thus decreasing the download time considerably (I got a factor 10 in my setup).

Thanks for your consideration and have a nice day