### PR TITLE
Libsylph cleanup

### DIFF
--- a/libsylph/account.c
+++ b/libsylph/account.c
@@ -276,7 +276,7 @@ gboolean account_address_exist(const gchar *address)
 		}
 	}
 
-	return (gboolean)g_hash_table_lookup(address_table, address);
+	return g_hash_table_lookup(address_table, address) != NULL;
 }
 
 void account_foreach(AccountFunc func, gpointer user_data)

--- a/libsylph/account.c
+++ b/libsylph/account.c
@@ -486,6 +486,5 @@ void account_updated(void)
 		address_table = NULL;
 	}
 
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "account-updated");
+	APP_EMIT("account-updated");
 }

--- a/libsylph/account.h
+++ b/libsylph/account.h
@@ -32,6 +32,10 @@ typedef gint	(*AccountFunc)	(PrefsAccount	*ac_prefs,
 
 extern PrefsAccount *cur_account;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void	      account_read_config_all	(void);
 void	      account_write_config_all	(void);
 
@@ -66,5 +70,9 @@ void	      account_destroy		(PrefsAccount	*ac_prefs);
 void	      account_update_lock	(void);
 void	      account_update_unlock	(void);
 void	      account_updated		(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ACCOUNT_H__ */

--- a/libsylph/codeconv.c
+++ b/libsylph/codeconv.c
@@ -1875,7 +1875,7 @@ static const struct {
 static GHashTable *conv_get_charset_to_str_table(void)
 {
 	static GHashTable *table;
-	gint i;
+	size_t i;
 	S_LOCK_DEFINE_STATIC(table);
 
 	S_LOCK(table);
@@ -1905,7 +1905,7 @@ static GHashTable *conv_get_charset_from_str_table(void)
 	static GHashTable *table;
 	S_LOCK_DEFINE_STATIC(table);
 
-	gint i;
+	size_t i;
 
 	S_LOCK(table);
 
@@ -1949,13 +1949,13 @@ CharSet conv_get_locale_charset(void)
 	const gchar *cur_locale;
 	const gchar *p;
 #if !defined(G_OS_WIN32) && !defined(__APPLE__)
-	gint i;
+	size_t i;
 #endif
 	S_LOCK_DEFINE_STATIC(cur_charset);
 
 	S_LOCK(cur_charset);
 
-	if (cur_charset != -1) {
+	if ((int) cur_charset != -1) {
 		S_UNLOCK(cur_charset);
 		return cur_charset;
 	}
@@ -2055,12 +2055,12 @@ CharSet conv_get_outgoing_charset(void)
 	static CharSet out_charset = -1;
 	const gchar *cur_locale;
 	const gchar *p;
-	gint i;
+	size_t i;
 	S_LOCK_DEFINE_STATIC(out_charset);
 
 	S_LOCK(out_charset);
 
-	if (out_charset != -1) {
+	if ((int) out_charset != -1) {
 		S_UNLOCK(out_charset);
 		return out_charset;
 	}
@@ -2266,9 +2266,9 @@ void conv_encode_header(gchar *dest, gint len, const gchar *src,
 			const gchar *out_encoding)
 {
 	const gchar *src_encoding;
-	gint mimestr_len;
+	size_t mimestr_len;
 	gchar *mimesep_enc;
-	gint left;
+	size_t left;
 	const gchar *srcp = src;
 	gchar *destp = dest;
 	gboolean use_base64;
@@ -2309,7 +2309,7 @@ void conv_encode_header(gchar *dest, gint len, const gchar *src,
 
 		/* output as it is if the next word is ASCII string */
 		if (!is_next_nonascii(srcp)) {
-			gint word_len;
+			size_t word_len;
 
 			word_len = get_next_word_len(srcp);
 			LBREAK_IF_REQUIRED(left < word_len, TRUE);
@@ -2495,7 +2495,7 @@ static gchar *encode_rfc2231_filename(const gchar *str)
 gchar *conv_encode_filename(const gchar *src, const gchar *param_name,
 			    const gchar *out_encoding)
 {
-	gint name_len, max_linelen;
+	size_t name_len, max_linelen;
 	gchar *out_str, *enc_str;
 	gchar cur_param[80];
 	GString *string;
@@ -2739,7 +2739,7 @@ CharSet conv_check_file_encoding(const gchar *file)
 
 		/* search UTF-16 CR/LF */
 		if (memchr(buf, 0x00, size * 2) != NULL) {
-			gint i;
+			size_t i;
 			guchar c1, c2;
 
 			for (i = 0; i < size; i++) {

--- a/libsylph/codeconv.c
+++ b/libsylph/codeconv.c
@@ -2722,7 +2722,7 @@ CharSet conv_check_file_encoding(const gchar *file)
 	if ((size = fread(buf, 2, BUFFSIZE / 2, fp)) > 0) {
 		CharSet guess_enc = C_AUTO;
 
-		debug_print("conv_check_file_encoding: check first %d bytes of file %s\n", size * 2, file);
+		debug_print("conv_check_file_encoding: check first %zd bytes of file %s\n", size * 2, file);
 
 		/* BOM check */
 		if ((buf[0] & 0xff) == 0xfe && (buf[1] & 0xff) == 0xff) {

--- a/libsylph/codeconv.c
+++ b/libsylph/codeconv.c
@@ -35,6 +35,9 @@
 #endif
 
 #include <iconv.h>
+#ifndef ICONV_CONST
+#define ICONV_CONST
+#endif
 
 #include "codeconv.h"
 #include "prefs_common.h"

--- a/libsylph/filter.c
+++ b/libsylph/filter.c
@@ -191,7 +191,7 @@ gint filter_action_exec(FilterRule *rule, MsgInfo *msginfo, const gchar *file,
 			debug_print("filter_action_exec(): mark as read\n");
 			if (msginfo->folder) {
 				if (MSG_IS_NEW(fltinfo->flags))
-					msginfo->folder->new--;
+					msginfo->folder->new_count--;
 				if (MSG_IS_UNREAD(fltinfo->flags))
 					msginfo->folder->unread--;
 			}

--- a/libsylph/filter.c
+++ b/libsylph/filter.c
@@ -566,10 +566,10 @@ static gboolean filter_match_cond(FilterCond *cond, MsgInfo *msginfo,
 			debug_print("filter-log: %s: CMD_TEST, str_value: [%s]%s\n", G_STRFUNC, sv, nm);
 			break;
 		case FLT_COND_SIZE_GREATER:
-			debug_print("filter-log: %s: SIZE_GREATER: %u %s %d (KB)%s\n", G_STRFUNC, msginfo->size, not_match ? "<=" : ">", cond->int_value, nm);
+			debug_print("filter-log: %s: SIZE_GREATER: %" G_GSIZE_FORMAT " %s %d (KB)%s\n", G_STRFUNC, msginfo->size, not_match ? "<=" : ">", cond->int_value, nm);
 			break;
 		case FLT_COND_AGE_GREATER:
-			debug_print("filter-log: %s: AGE_GREATER: %lld (sec) %s %d (day)%s\n", G_STRFUNC, timediff, not_match ? "<=" : ">", cond->int_value, nm);
+			debug_print("filter-log: %s: AGE_GREATER: %" G_GINT64_FORMAT " (sec) %s %d (day)%s\n", G_STRFUNC, timediff, not_match ? "<=" : ">", cond->int_value, nm);
 			break;
 		case FLT_COND_UNREAD:
 			debug_print("filter-log: %s: UNREAD%s\n", G_STRFUNC, nm);

--- a/libsylph/folder.c
+++ b/libsylph/folder.c
@@ -1945,7 +1945,7 @@ static void folder_write_list_recursive(GNode *node, gpointer data)
 		}
 
 		fprintf(fp,
-			" mtime=\"%lld\" new=\"%d\" unread=\"%d\" total=\"%d\"",
+			" mtime=\"%" G_GINT64_FORMAT "\" new=\"%d\" unread=\"%d\" total=\"%d\"",
 			(gint64)item->mtime, item->new, item->unread, item->total);
 
 		if (item->account)

--- a/libsylph/folder.c
+++ b/libsylph/folder.c
@@ -592,8 +592,7 @@ void folder_write_list(void)
 	if (prefs_file_close(pfile) < 0)
 		g_warning("failed to write folder list.\n");
 
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "folderlist-updated");
+	APP_EMIT("folderlist-updated");
 }
 
 struct TotalMsgStatus

--- a/libsylph/folder.c
+++ b/libsylph/folder.c
@@ -622,7 +622,7 @@ static gboolean folder_get_status_full_all_func(GNode *node, gpointer data)
 
 	if (status->str) {
 		id = folder_item_get_identifier(item);
-		g_string_sprintfa(status->str, "%5d %5d %5d %s\n",
+		g_string_append_printf(status->str, "%5d %5d %5d %s\n",
 				  item->new, item->unread,
 				  item->total, id);
 		g_free(id);
@@ -681,7 +681,7 @@ gchar *folder_get_status(GPtrArray *folders, gboolean full)
 				gchar *id;
 
 				id = folder_item_get_identifier(item);
-				g_string_sprintfa(str, "%5d %5d %5d %s\n",
+				g_string_append_printf(str, "%5d %5d %5d %s\n",
 						  item->new, item->unread,
 						  item->total, id);
 				g_free(id);
@@ -693,9 +693,9 @@ gchar *folder_get_status(GPtrArray *folders, gboolean full)
 	}
 
 	if (full)
-		g_string_sprintfa(str, "%5d %5d %5d\n", new, unread, total);
+		g_string_append_printf(str, "%5d %5d %5d\n", new, unread, total);
 	else
-		g_string_sprintfa(str, "%d %d %d\n", new, unread, total);
+		g_string_append_printf(str, "%d %d %d\n", new, unread, total);
 
 	ret = str->str;
 	g_string_free(str, FALSE);

--- a/libsylph/folder.c
+++ b/libsylph/folder.c
@@ -241,7 +241,7 @@ FolderItem *folder_item_new(const gchar *name, const gchar *path)
 	item->name = g_strdup(name);
 	item->path = g_strdup(path);
 	item->mtime = 0;
-	item->new = 0;
+	item->new_count = 0;
 	item->unread = 0;
 	item->total = 0;
 	item->unmarked_num = 0;
@@ -294,7 +294,7 @@ FolderItem *folder_item_copy(FolderItem *item)
 	new_item->name = g_strdup(item->name);
 	new_item->path = g_strdup(item->path);
 	new_item->mtime = item->mtime;
-	new_item->new = item->new;
+	new_item->new_count = item->new_count;
 	new_item->unread = item->unread;
 	new_item->total = item->total;
 	new_item->unmarked_num = item->unmarked_num;
@@ -615,14 +615,14 @@ static gboolean folder_get_status_full_all_func(GNode *node, gpointer data)
 
 	if (!item->path) return FALSE;
 
-	status->new += item->new;
+	status->new += item->new_count;
 	status->unread += item->unread;
 	status->total += item->total;
 
 	if (status->str) {
 		id = folder_item_get_identifier(item);
 		g_string_append_printf(status->str, "%5d %5d %5d %s\n",
-				  item->new, item->unread,
+				  item->new_count, item->unread,
 				  item->total, id);
 		g_free(id);
 	}
@@ -672,7 +672,7 @@ gchar *folder_get_status(GPtrArray *folders, gboolean full)
 			FolderItem *item;
 
 			item = g_ptr_array_index(folders, i);
-			new += item->new;
+			new += item->new_count;
 			unread += item->unread;
 			total += item->total;
 
@@ -681,7 +681,7 @@ gchar *folder_get_status(GPtrArray *folders, gboolean full)
 
 				id = folder_item_get_identifier(item);
 				g_string_append_printf(str, "%5d %5d %5d %s\n",
-						  item->new, item->unread,
+						  item->new_count, item->unread,
 						  item->total, id);
 				g_free(id);
 			}
@@ -1730,7 +1730,7 @@ static gboolean folder_build_tree(GNode *node, gpointer data)
 	item = folder_item_new(name, path);
 	item->stype = stype;
 	item->mtime = mtime;
-	item->new = new;
+	item->new_count = new;
 	item->unread = unread;
 	item->total = total;
 	item->no_sub = no_sub;
@@ -1945,7 +1945,7 @@ static void folder_write_list_recursive(GNode *node, gpointer data)
 
 		fprintf(fp,
 			" mtime=\"%" G_GINT64_FORMAT "\" new=\"%d\" unread=\"%d\" total=\"%d\"",
-			(gint64)item->mtime, item->new, item->unread, item->total);
+			(gint64)item->mtime, item->new_count, item->unread, item->total);
 
 		if (item->account)
 			fprintf(fp, " account_id=\"%d\"",

--- a/libsylph/folder.h
+++ b/libsylph/folder.h
@@ -279,7 +279,7 @@ struct _FolderItem
 
 	stime_t mtime;
 
-	gint new;
+	gint new_count;
 	gint unread;
 	gint total;
 	gint unmarked_num;
@@ -328,6 +328,10 @@ struct _FolderItem
 
 	gpointer data;
 };
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 Folder     *folder_new			(FolderType	 type,
 					 const gchar	*name,
@@ -471,5 +475,9 @@ gchar *folder_item_get_cache_file	(FolderItem	*item);
 gchar *folder_item_get_mark_file	(FolderItem	*item);
 
 gint   folder_item_close		(FolderItem	*item);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __FOLDER_H__ */

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -130,9 +130,6 @@ static gint imap_session_reconnect	(IMAPSession	*session);
 static void imap_session_destroy	(Session	*session);
 /* static void imap_session_destroy_all	(void); */
 
-static gint imap_search_flags		(IMAPSession	*session,
-					 GArray	       **uids,
-					 GHashTable    **flags_table);
 static gint imap_fetch_flags		(IMAPSession	*session,
 					 GArray	       **uids,
 					 GHashTable    **flags_table);
@@ -377,9 +374,6 @@ static gint imap_cmd_subscribe	(IMAPSession	*session,
 				 const gchar	*folder);
 static gint imap_cmd_envelope	(IMAPSession	*session,
 				 const gchar	*seq_set);
-static gint imap_cmd_search	(IMAPSession	*session,
-				 const gchar	*criteria,
-				 GArray        **result);
 static gint imap_cmd_fetch	(IMAPSession	*session,
 				 guint32	 uid,
 				 const gchar	*filename);
@@ -432,8 +426,6 @@ static GSList *imap_get_seq_set_from_msglist	(GSList		*msglist,
 						 gint		 limit);
 static gint imap_seq_set_get_count		(const gchar	*seq_set);
 static void imap_seq_set_free			(GSList		*seq_list);
-
-static GHashTable *imap_get_uid_table		(GArray		*array);
 
 static gboolean imap_rename_folder_func		(GNode		*node,
 						 gpointer	 data);
@@ -837,6 +829,30 @@ static void imap_session_destroy_all(void)
 
 #define THROW goto catch
 
+#if 0
+static gint imap_cmd_search	(IMAPSession	*session,
+				 const gchar	*criteria,
+				 GArray        **result);
+
+static GHashTable *imap_get_uid_table(GArray *array)
+{
+	GHashTable *table;
+	gint i;
+	guint32 uid;
+
+	g_return_val_if_fail(array != NULL, NULL);
+
+	table = g_hash_table_new(NULL, g_direct_equal);
+
+	for (i = 0; i < array->len; i++) {
+		uid = g_array_index(array, guint32, i);
+		g_hash_table_insert(table, GUINT_TO_POINTER(uid),
+				    GINT_TO_POINTER(i + 1));
+	}
+
+	return table;
+}
+
 static gint imap_search_flags(IMAPSession *session, GArray **uids,
 			      GHashTable **flags_table)
 {
@@ -898,6 +914,7 @@ static gint imap_search_flags(IMAPSession *session, GArray **uids,
 
 	return IMAP_SUCCESS;
 }
+#endif
 
 static gint imap_fetch_flags(IMAPSession *session, GArray **uids,
 			     GHashTable **flags_table)
@@ -4195,6 +4212,7 @@ static gint imap_cmd_subscribe(IMAPSession *session, const gchar *folder)
 
 #define THROW(err) { ok = err; goto catch; }
 
+#if 0
 static gint imap_cmd_search(IMAPSession *session, const gchar *criteria,
 			    GArray **result)
 {
@@ -4241,6 +4259,7 @@ catch:
 
 	return ok;
 }
+#endif
 
 typedef struct _IMAPCmdFetchData
 {
@@ -5086,25 +5105,6 @@ static void imap_seq_set_free(GSList *seq_list)
 {
 	slist_free_strings(seq_list);
 	g_slist_free(seq_list);
-}
-
-static GHashTable *imap_get_uid_table(GArray *array)
-{
-	GHashTable *table;
-	gint i;
-	guint32 uid;
-
-	g_return_val_if_fail(array != NULL, NULL);
-
-	table = g_hash_table_new(NULL, g_direct_equal);
-
-	for (i = 0; i < array->len; i++) {
-		uid = g_array_index(array, guint32, i);
-		g_hash_table_insert(table, GUINT_TO_POINTER(uid),
-				    GINT_TO_POINTER(i + 1));
-	}
-
-	return table;
 }
 
 static gboolean imap_rename_folder_func(GNode *node, gpointer data)

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -1392,7 +1392,7 @@ static gint imap_add_msgs(Folder *folder, FolderItem *dest, GSList *file_list,
 	gint count = 1;
 	gint total;
 	gint ok;
-	GTimeVal tv_prev, tv_cur;
+	gint64 tv_prev, tv_cur;
 
 	g_return_val_if_fail(folder != NULL, -1);
 	g_return_val_if_fail(dest != NULL, -1);
@@ -1401,7 +1401,7 @@ static gint imap_add_msgs(Folder *folder, FolderItem *dest, GSList *file_list,
 	session = imap_session_get(folder);
 	if (!session) return -1;
 
-	g_get_current_time(&tv_prev);
+	tv_prev = g_get_real_time();
 	ui_update();
 
 	ok = imap_status(session, IMAP_FOLDER(folder), dest->path,
@@ -1440,10 +1440,8 @@ static gint imap_add_msgs(Folder *folder, FolderItem *dest, GSList *file_list,
 		    dest->stype == F_DRAFT)
 			iflags |= IMAP_FLAG_SEEN;
 
-		g_get_current_time(&tv_cur);
-		if (tv_cur.tv_sec > tv_prev.tv_sec ||
-		    tv_cur.tv_usec - tv_prev.tv_usec >
-		    PROGRESS_UPDATE_INTERVAL * 1000) {
+		tv_cur = g_get_real_time();
+		if (tv_cur - tv_prev > PROGRESS_UPDATE_INTERVAL * 1000) {
 			status_print(_("Appending messages to %s (%d / %d)"),
 				     dest->path, count, total);
 			progress_show(count, total);
@@ -2755,13 +2753,13 @@ static gint imap_get_uncached_messages_func(IMAPSession *session, gpointer data)
 	GString *str;
 	MsgInfo *msginfo;
 	gint count = 1;
-	GTimeVal tv_prev, tv_cur;
+	gint64 tv_prev, tv_cur;
 	IMAPGetData *get_data = (IMAPGetData *)data;
 	FolderItem *item = get_data->item;
 	gint exists = get_data->exists;
 	gboolean update_count = get_data->update_count;
 
-	g_get_current_time(&tv_prev);
+	tv_prev = g_get_real_time();
 #ifndef USE_THREADS
 	ui_update();
 #endif
@@ -2774,10 +2772,8 @@ static gint imap_get_uncached_messages_func(IMAPSession *session, gpointer data)
 
 	for (;;) {
 		if (exists > 0 && count <= exists) {
-			g_get_current_time(&tv_cur);
-			if (tv_cur.tv_sec > tv_prev.tv_sec ||
-			    tv_cur.tv_usec - tv_prev.tv_usec >
-			    PROGRESS_UPDATE_INTERVAL * 1000) {
+			tv_cur = g_get_real_time();
+			if (tv_cur - tv_prev > PROGRESS_UPDATE_INTERVAL * 1000) {
 #if USE_THREADS
 				((IMAPRealSession *)session)->prog_count = count;
 				g_main_context_wakeup(NULL);

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -1462,8 +1462,7 @@ static gint imap_add_msgs(Folder *folder, FolderItem *dest, GSList *file_list,
 			return -1;
 		}
 
-		if (syl_app_get())
-			g_signal_emit_by_name(syl_app_get(), "add-msg", dest, fileinfo->file, new_uid);
+		APP_EMITA("add-msg", dest, fileinfo->file, new_uid);
 
 		if (!session->uidplus)
 			last_uid++;
@@ -1601,8 +1600,7 @@ static gint imap_do_copy_msgs(Folder *folder, FolderItem *dest, GSList *msglist,
 	for (cur = msglist; cur != NULL; cur = cur->next) {
 		msginfo = (MsgInfo *)cur->data;
 
-		if (syl_app_get())
-			g_signal_emit_by_name(syl_app_get(), "add-msg", dest, NULL, 0);
+		APP_EMITA("add-msg", dest, NULL, 0);
 
 		dest->total++;
 		if (MSG_IS_NEW(msginfo->flags))
@@ -1787,8 +1785,7 @@ static gint imap_remove_msgs(Folder *folder, FolderItem *item, GSList *msglist)
 		MsgInfo *msginfo = (MsgInfo *)cur->data;
 		guint32 uid = msginfo->msgnum;
 
-		if (syl_app_get())
-			g_signal_emit_by_name(syl_app_get(), "remove-msg", item, NULL, uid);
+		APP_EMITA("remove-msg", item, NULL, uid);
 
 		if (dir_exist)
 			remove_numbered_files(dir, uid, uid);
@@ -1841,8 +1838,7 @@ static gint imap_remove_all_msg(Folder *folder, FolderItem *item)
 		return ok;
 	}
 
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "remove-all-msg", item);
+	APP_EMITA("remove-all-msg", item);
 
 	item->new = item->unread = item->total = 0;
 	item->updated = TRUE;
@@ -2668,9 +2664,7 @@ static gint imap_rename_folder_real(Folder *folder, FolderItem *item,
 	g_free(real_newpath);
 
 	new_id = folder_item_get_identifier(item);
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "move-folder", item,
-				      old_id, new_id);
+	APP_EMITA("move-folder", item, old_id, new_id);
 	g_free(new_id);
 	g_free(old_id);
 
@@ -2727,8 +2721,7 @@ static gint imap_remove_folder(Folder *folder, FolderItem *item)
 		g_warning("can't remove directory '%s'\n", cache_dir);
 	g_free(cache_dir);
 
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "remove-folder", item);
+	APP_EMITA("remove-folder", item);
 	folder_item_remove(item);
 
 	return 0;

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -35,6 +35,9 @@
 #if HAVE_ICONV
 #  include <iconv.h>
 #endif
+#ifndef ICONV_CONST
+#define ICONV_CONST
+#endif
 
 #include "sylmain.h"
 #include "imap.h"

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -1025,7 +1025,7 @@ static GSList *imap_get_msg_list_full(Folder *folder, FolderItem *item,
 	g_return_val_if_fail(FOLDER_TYPE(folder) == F_IMAP, NULL);
 	g_return_val_if_fail(folder->account != NULL, NULL);
 
-	item->new = item->unread = item->total = 0;
+	item->new_count = item->unread = item->total = 0;
 
 	session = imap_session_get(folder);
 
@@ -1106,7 +1106,7 @@ static GSList *imap_get_msg_list_full(Folder *folder, FolderItem *item,
 				imap_delete_cached_message
 					(item, msginfo->msgnum);
 				if (MSG_IS_NEW(msginfo->flags))
-					item->new--;
+					item->new_count--;
 				if (MSG_IS_UNREAD(msginfo->flags))
 					item->unread--;
 				item->total--;
@@ -1126,7 +1126,7 @@ static GSList *imap_get_msg_list_full(Folder *folder, FolderItem *item,
 				}
 			} else {
 				if (MSG_IS_NEW(msginfo->flags)) {
-					item->new--;
+					item->new_count--;
 					item->mark_dirty = TRUE;
 				}
 				if (MSG_IS_UNREAD(msginfo->flags)) {
@@ -1604,7 +1604,7 @@ static gint imap_do_copy_msgs(Folder *folder, FolderItem *dest, GSList *msglist,
 
 		dest->total++;
 		if (MSG_IS_NEW(msginfo->flags))
-			dest->new++;
+			dest->new_count++;
 		if (MSG_IS_UNREAD(msginfo->flags))
 			dest->unread++;
 	}
@@ -1791,7 +1791,7 @@ static gint imap_remove_msgs(Folder *folder, FolderItem *item, GSList *msglist)
 			remove_numbered_files(dir, uid, uid);
 		item->total--;
 		if (MSG_IS_NEW(msginfo->flags))
-			item->new--;
+			item->new_count--;
 		if (MSG_IS_UNREAD(msginfo->flags))
 			item->unread--;
 		MSG_SET_TMP_FLAGS(msginfo->flags, MSG_INVALID);
@@ -1840,7 +1840,7 @@ static gint imap_remove_all_msg(Folder *folder, FolderItem *item)
 
 	APP_EMITA("remove-all-msg", item);
 
-	item->new = item->unread = item->total = 0;
+	item->new_count = item->unread = item->total = 0;
 	item->updated = TRUE;
 
 	dir = folder_item_get_path(item);
@@ -1905,7 +1905,7 @@ static gint imap_scan_folder(Folder *folder, FolderItem *item)
 			 &messages, &recent, &uid_next, &uid_validity, &unseen);
 	if (ok != IMAP_SUCCESS) return -1;
 
-	item->new = unseen > 0 ? recent : 0;
+	item->new_count = unseen > 0 ? recent : 0;
 	item->unread = unseen;
 	item->total = messages;
 	item->last_num = (messages > 0 && uid_next > 0) ? uid_next - 1 : 0;
@@ -2030,7 +2030,7 @@ static gint imap_scan_tree_recursive(IMAPSession *session, FolderItem *item,
 			old_item->no_sub = new_item->no_sub;
 			old_item->no_select = new_item->no_select;
 			if (old_item->no_select == TRUE)
-				old_item->new = old_item->unread =
+				old_item->new_count = old_item->unread =
 					old_item->total = 0;
 			if (old_item->no_sub == TRUE && node->children) {
 				debug_print("folder '%s' doesn't have "
@@ -2817,7 +2817,7 @@ static gint imap_get_uncached_messages_func(IMAPSession *session, gpointer data)
 		}
 		if (update_count) {
 			if (MSG_IS_NEW(msginfo->flags))
-				item->new++;
+				item->new_count++;
 			if (MSG_IS_UNREAD(msginfo->flags))
 				item->unread++;
 		}

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -1041,7 +1041,6 @@ static GSList *imap_get_msg_list_full(Folder *folder, FolderItem *item,
 		GArray *uids;
 		GHashTable *msg_table;
 		GHashTable *flags_table;
-		guint32 cache_last;
 		guint32 begin = 0;
 		GSList *cur, *next = NULL;
 		MsgInfo *msginfo;
@@ -1051,7 +1050,7 @@ static GSList *imap_get_msg_list_full(Folder *folder, FolderItem *item,
 		/* get cache data */
 		mlist = procmsg_read_cache(item, FALSE);
 		procmsg_set_flags(mlist, item);
-		cache_last = procmsg_get_last_num_in_msg_list(mlist);
+		//cache_last = procmsg_get_last_num_in_msg_list(mlist);
 
 		/* get all UID list and flags */
 #if 0
@@ -2846,7 +2845,6 @@ static GSList *imap_get_uncached_messages(IMAPSession *session,
 {
 	IMAPGetData get_data = {item, exists, update_count, NULL};
 	gchar seq_set[22];
-	gint ok;
 
 	g_return_val_if_fail(session != NULL, NULL);
 	g_return_val_if_fail(item != NULL, NULL);
@@ -2865,11 +2863,11 @@ static GSList *imap_get_uncached_messages(IMAPSession *session,
 	}
 
 #if USE_THREADS
-	ok = imap_thread_run_progress(session, imap_get_uncached_messages_func,
+	imap_thread_run_progress(session, imap_get_uncached_messages_func,
 				      imap_get_uncached_messages_progress_func,
 				      &get_data);
 #else
-	ok = imap_get_uncached_messages_func(session, &get_data);
+	imap_get_uncached_messages_func(session, &get_data);
 #endif
 
 	progress_show(0, 0);
@@ -3403,7 +3401,7 @@ static MsgInfo *imap_parse_envelope(IMAPSession *session, FolderItem *item,
 	gchar buf[IMAPBUFSIZE];
 	MsgInfo *msginfo = NULL;
 	gchar *cur_pos;
-	gint msgnum;
+	//gint msgnum;
 	guint32 uid = 0;
 	size_t size = 0;
 	MsgFlags flags = {0, 0}, imap_flags = {0, 0};
@@ -3432,7 +3430,7 @@ static MsgInfo *imap_parse_envelope(IMAPSession *session, FolderItem *item,
 }
 
 	PARSE_ONE_ELEMENT(' ');
-	msgnum = atoi(buf);
+	//msgnum = atoi(buf);
 
 	PARSE_ONE_ELEMENT(' ');
 	g_return_val_if_fail(!strcmp(buf, "FETCH"), NULL);
@@ -3844,7 +3842,6 @@ static gint imap_cmd_auth_oauth2(IMAPSession *session, const gchar *user,
                                  const gchar *pass)
 {
 	PrefsAccount *account;
-	gchar *p;
 	gchar *response64;
 	gint ok;
 
@@ -4636,7 +4633,6 @@ static gint imap_cmd_ok(IMAPSession *session, GPtrArray *argbuf)
 
 static gint imap_cmd_gen_send(IMAPSession *session, const gchar *format, ...)
 {
-	IMAPRealSession *real = (IMAPRealSession *)session;
 	gchar buf[IMAPBUFSIZE];
 	gchar tmp[IMAPBUFSIZE];
 	gchar *p;
@@ -4647,7 +4643,7 @@ static gint imap_cmd_gen_send(IMAPSession *session, const gchar *format, ...)
 	va_end(args);
 
 #if USE_THREADS
-	if (real->is_running) {
+	if (((IMAPRealSession *)session)->is_running) {
 		g_warning("imap_cmd_gen_send: cannot send command because another command is already running.");
 		return IMAP_EAGAIN;
 	}

--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -2598,7 +2598,7 @@ static gint imap_rename_folder_real(Folder *folder, FolderItem *item,
 		if (strchr(item->path, '/')) {
 			gchar *dirpath;
 
-			dirpath = g_dirname(item->path);
+			dirpath = g_path_get_dirname(item->path);
 			newpath = g_strconcat(dirpath, "/", name, NULL);
 			g_free(dirpath);
 		} else
@@ -5009,9 +5009,9 @@ static GSList *imap_get_seq_set_from_msglist(GSList *msglist, gint limit)
 			if (str->len > 0)
 				g_string_append_c(str, ',');
 			if (first == last)
-				g_string_sprintfa(str, "%u", first);
+				g_string_append_printf(str, "%u", first);
 			else
-				g_string_sprintfa(str, "%u:%u", first, last);
+				g_string_append_printf(str, "%u:%u", first, last);
 
 			first = next;
 
@@ -5026,9 +5026,9 @@ static GSList *imap_get_seq_set_from_msglist(GSList *msglist, gint limit)
 			if (str->len > 0)
 				g_string_append_c(str, ',');
 			if (first == last)
-				g_string_sprintfa(str, "%u", first);
+				g_string_append_printf(str, "%u", first);
 			else
-				g_string_sprintfa(str, "%u:%u", first, last);
+				g_string_append_printf(str, "%u:%u", first, last);
 
 			first = next;
 

--- a/libsylph/mbox.c
+++ b/libsylph/mbox.c
@@ -192,7 +192,7 @@ gint proc_mbox_full(FolderItem *dest, const gchar *mbox,
 				} else if (!strncmp(buf, "From ", 5)) {
 					continue;
 				} else if (!strncmp(buf, ">From ", 6)) {
-					g_memmove(buf, buf + 1, strlen(buf));
+					memmove(buf, buf + 1, strlen(buf));
 					is_next_msg = TRUE;
 					break;
 				} else {

--- a/libsylph/md5.c
+++ b/libsylph/md5.c
@@ -124,10 +124,10 @@ MD5Update(struct MD5Context *ctx, guint8 const *buf, guint len)
       t = 64 - t;
       if (len < t) 
         {
-          g_memmove(p, buf, len);
+          memmove(p, buf, len);
           return;
 	}
-      g_memmove(p, buf, t);
+      memmove(p, buf, t);
       if (ctx->doByteReverse)
         byteReverse(ctx->in, 16);
       MD5Transform(ctx->buf, (guint32 *) ctx->in);
@@ -138,7 +138,7 @@ MD5Update(struct MD5Context *ctx, guint8 const *buf, guint len)
 
   while (len >= 64) 
     {
-      g_memmove(ctx->in, buf, 64);
+      memmove(ctx->in, buf, 64);
       if (ctx->doByteReverse)
         byteReverse(ctx->in, 16);
       MD5Transform(ctx->buf, (guint32 *) ctx->in);
@@ -148,7 +148,7 @@ MD5Update(struct MD5Context *ctx, guint8 const *buf, guint len)
 
   /* Handle any remaining bytes of data. */
 
-  g_memmove(ctx->in, buf, len);
+  memmove(ctx->in, buf, len);
 }
 
 /*
@@ -199,7 +199,7 @@ MD5Final(guint8 digest[16], struct MD5Context *ctx)
   MD5Transform(ctx->buf, (guint32 *) ctx->in);
   if (ctx->doByteReverse)
     byteReverse((guint8 *) ctx->buf, 4);
-  g_memmove(digest, ctx->buf, 16);
+  memmove(digest, ctx->buf, 16);
   memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
 }
 

--- a/libsylph/mh.c
+++ b/libsylph/mh.c
@@ -515,8 +515,7 @@ static gint mh_add_msgs(Folder *folder, FolderItem *dest, GSList *file_list,
 			}
 		}
 
-		if (syl_app_get())
-			g_signal_emit_by_name(syl_app_get(), "add-msg", dest, destfile, dest->last_num + 1);
+		APP_EMITA("add-msg", dest, destfile, dest->last_num + 1);
 
 		g_free(destfile);
 		dest->last_num++;
@@ -629,8 +628,7 @@ static gint mh_add_msgs_msginfo(Folder *folder, FolderItem *dest,
 			}
 		}
 
-		if (syl_app_get())
-			g_signal_emit_by_name(syl_app_get(), "add-msg", dest, destfile, dest->last_num + 1);
+		APP_EMITA("add-msg", dest, destfile, dest->last_num + 1);
 
 		g_free(srcfile);
 		g_free(destfile);
@@ -712,7 +710,7 @@ static gint mh_do_move_msgs(Folder *folder, FolderItem *dest, GSList *msglist)
 		if (!destfile) break;
 		srcfile = procmsg_get_message_file(msginfo);
 
-		/* g_signal_emit_by_name(syl_app_get(), "remove-msg", src, srcfile, msginfo->msgnum); */
+		/* APP_EMITA("remove-msg", src, srcfile, msginfo->msgnum); */
 
 		if (move_file(srcfile, destfile, FALSE) < 0) {
 			g_free(srcfile);
@@ -720,10 +718,8 @@ static gint mh_do_move_msgs(Folder *folder, FolderItem *dest, GSList *msglist)
 			break;
 		}
 
-		if (syl_app_get()) {
-			g_signal_emit_by_name(syl_app_get(), "add-msg", dest, destfile, dest->last_num + 1);
-			g_signal_emit_by_name(syl_app_get(), "remove-msg", src, srcfile, msginfo->msgnum);
-		}
+		APP_EMITA("add-msg", dest, destfile, dest->last_num + 1);
+		APP_EMITA("remove-msg", src, srcfile, msginfo->msgnum);
 
 		g_free(srcfile);
 		g_free(destfile);
@@ -839,8 +835,7 @@ static gint mh_copy_msgs(Folder *folder, FolderItem *dest, GSList *msglist)
 			break;
 		}
 
-		if (syl_app_get())
-			g_signal_emit_by_name(syl_app_get(), "add-msg", dest, destfile, dest->last_num + 1);
+		APP_EMITA("add-msg", dest, destfile, dest->last_num + 1);
 
 		g_free(srcfile);
 		g_free(destfile);
@@ -876,8 +871,7 @@ static gint mh_remove_msg(Folder *folder, FolderItem *item, MsgInfo *msginfo)
 	file = mh_fetch_msg(folder, item, msginfo->msgnum);
 	g_return_val_if_fail(file != NULL, -1);
 
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "remove-msg", item, file, msginfo->msgnum);
+	APP_EMITA("remove-msg", item, file, msginfo->msgnum);
 
 	S_LOCK(mh);
 
@@ -915,8 +909,7 @@ static gint mh_remove_all_msg(Folder *folder, FolderItem *item)
 
 	path = folder_item_get_path(item);
 	g_return_val_if_fail(path != NULL, -1);
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "remove-all-msg", item);
+	APP_EMITA("remove-all-msg", item);
 
 	S_LOCK(mh);
 
@@ -1407,9 +1400,7 @@ static gint mh_move_folder_real(Folder *folder, FolderItem *item,
 	g_free(paths[1]);
 
 	new_id = folder_item_get_identifier(item);
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "move-folder", item,
-				      old_id, new_id);
+	APP_EMITA("move-folder", item, old_id, new_id);
 	g_free(new_id);
 	g_free(old_id);
 
@@ -1448,8 +1439,7 @@ static gint mh_remove_folder(Folder *folder, FolderItem *item)
 	}
 
 	g_free(path);
-	if (syl_app_get())
-		g_signal_emit_by_name(syl_app_get(), "remove-folder", item);
+	APP_EMITA("remove-folder", item);
 	folder_item_remove(item);
 
 	S_UNLOCK(mh);

--- a/libsylph/mh.c
+++ b/libsylph/mh.c
@@ -527,7 +527,7 @@ static gint mh_add_msgs(Folder *folder, FolderItem *dest, GSList *file_list,
 			/* resets new flags of existing messages on
 			   received mode */
 			if (dest->unmarked_num == 0)
-				dest->new = 0;
+				dest->new_count = 0;
 			dest->unmarked_num++;
 			procmsg_add_mark_queue(dest, dest->last_num, flags);
 		} else {
@@ -535,7 +535,7 @@ static gint mh_add_msgs(Folder *folder, FolderItem *dest, GSList *file_list,
 		}
 		procmsg_add_cache_queue(dest, dest->last_num, msginfo);
 		if (MSG_IS_NEW(flags))
-			dest->new++;
+			dest->new_count++;
 		if (MSG_IS_UNREAD(flags))
 			dest->unread++;
 	}
@@ -641,7 +641,7 @@ static gint mh_add_msgs_msginfo(Folder *folder, FolderItem *dest,
 			/* resets new flags of existing messages on
 			   received mode */
 			if (dest->unmarked_num == 0)
-				dest->new = 0;
+				dest->new_count = 0;
 			dest->unmarked_num++;
 			procmsg_add_mark_queue(dest, dest->last_num,
 					       msginfo->flags);
@@ -651,7 +651,7 @@ static gint mh_add_msgs_msginfo(Folder *folder, FolderItem *dest,
 		}
 		procmsg_add_cache_queue(dest, dest->last_num, msginfo);
 		if (MSG_IS_NEW(msginfo->flags))
-			dest->new++;
+			dest->new_count++;
 		if (MSG_IS_UNREAD(msginfo->flags))
 			dest->unread++;
 	}
@@ -735,8 +735,8 @@ static gint mh_do_move_msgs(Folder *folder, FolderItem *dest, GSList *msglist)
 		procmsg_add_cache_queue(dest, dest->last_num, msginfo);
 
 		if (MSG_IS_NEW(msginfo->flags)) {
-			src->new--;
-			dest->new++;
+			src->new_count--;
+			dest->new_count++;
 		}
 		if (MSG_IS_UNREAD(msginfo->flags)) {
 			src->unread--;
@@ -848,7 +848,7 @@ static gint mh_copy_msgs(Folder *folder, FolderItem *dest, GSList *msglist)
 		procmsg_add_cache_queue(dest, dest->last_num, msginfo);
 
 		if (MSG_IS_NEW(msginfo->flags))
-			dest->new++;
+			dest->new_count++;
 		if (MSG_IS_UNREAD(msginfo->flags))
 			dest->unread++;
 	}
@@ -887,7 +887,7 @@ static gint mh_remove_msg(Folder *folder, FolderItem *item, MsgInfo *msginfo)
 	item->updated = TRUE;
 	item->mtime = 0;
 	if (MSG_IS_NEW(msginfo->flags))
-		item->new--;
+		item->new_count--;
 	if (MSG_IS_UNREAD(msginfo->flags))
 		item->unread--;
 	MSG_SET_TMP_FLAGS(msginfo->flags, MSG_INVALID);
@@ -916,7 +916,7 @@ static gint mh_remove_all_msg(Folder *folder, FolderItem *item)
 	val = remove_all_numbered_files(path);
 	g_free(path);
 	if (val == 0) {
-		item->new = item->unread = item->total = 0;
+		item->new_count = item->unread = item->total = 0;
 		item->last_num = 0;
 		item->updated = TRUE;
 		item->mtime = 0;
@@ -1112,7 +1112,7 @@ static gint mh_scan_folder_full(Folder *folder, FolderItem *item,
 #endif
 
 	if (n_msg == 0)
-		item->new = item->unread = item->total = 0;
+		item->new_count = item->unread = item->total = 0;
 	else if (count_sum) {
 		gint new, unread, total, min, max_;
 
@@ -1125,7 +1125,7 @@ static gint mh_scan_folder_full(Folder *folder, FolderItem *item,
 		} else
 			item->unmarked_num = 0;
 
-		item->new = new;
+		item->new_count = new;
 		item->unread = unread;
 		item->total = n_msg;
 
@@ -1851,7 +1851,7 @@ static void mh_scan_tree_recursive(FolderItem *item)
 			new += n_msg - total;
 			unread += n_msg - total;
 		}
-		item->new = new;
+		item->new_count = new;
 		item->unread = unread;
 		item->total = n_msg;
 		item->updated = TRUE;

--- a/libsylph/mh.c
+++ b/libsylph/mh.c
@@ -1330,7 +1330,7 @@ static gint mh_move_folder_real(Folder *folder, FolderItem *item,
 	} else {
 		name_ = g_filename_from_utf8(name, -1, NULL, NULL, NULL);
 		utf8_name = g_strdup(name);
-		dirname = g_dirname(oldpath);
+		dirname = g_path_get_dirname(oldpath);
 		newpath = g_strconcat(dirname, G_DIR_SEPARATOR_S,
 				      name_ ? name_ : name, NULL);
 		g_free(dirname);
@@ -1385,7 +1385,7 @@ static gint mh_move_folder_real(Folder *folder, FolderItem *item,
 			newpath = utf8_name;
 	} else {
 		if (strchr(item->path, '/') != NULL) {
-			dirname = g_dirname(item->path);
+			dirname = g_path_get_dirname(item->path);
 			newpath = g_strconcat(dirname, "/", utf8_name, NULL);
 			g_free(dirname);
 			g_free(utf8_name);

--- a/libsylph/news.c
+++ b/libsylph/news.c
@@ -488,7 +488,7 @@ static gint news_scan_group(Folder *folder, FolderItem *item)
 	}
 
 	if (num == 0) {
-		item->new = item->unread = item->total = item->last_num = 0;
+		item->new_count = item->unread = item->total = item->last_num = 0;
 		return 0;
 	}
 
@@ -511,7 +511,7 @@ static gint news_scan_group(Folder *folder, FolderItem *item)
 		if (unread > num) unread = num;
 	}
 
-	item->new = new;
+	item->new_count = new;
 	item->unread = unread;
 	item->total = num;
 	item->last_num = last;

--- a/libsylph/news.c
+++ b/libsylph/news.c
@@ -969,7 +969,7 @@ static MsgInfo *news_parse_xover(const gchar *xover_str)
 	MsgInfo *msginfo;
 	gchar *subject, *sender, *size, *line, *date, *msgid, *ref, *tmp;
 	gchar *p;
-	gint num, size_int, line_int;
+	gint num, size_int;
 	gchar *xover_buf;
 
 	Xstrdup_a(xover_buf, xover_str, return NULL);
@@ -989,7 +989,7 @@ static MsgInfo *news_parse_xover(const gchar *xover_str)
 
 	num = atoi(xover_str);
 	size_int = atoi(size);
-	line_int = atoi(line);
+	//line_int = atoi(line);
 
 	/* set MsgInfo */
 	msginfo = g_new0(MsgInfo, 1);

--- a/libsylph/pop.c
+++ b/libsylph/pop.c
@@ -216,8 +216,6 @@ gint pop3_getauth_auth_recv(Pop3Session *session, const gchar *msg)
 
 gint pop3_getauth_auth_data_send(Pop3Session *session)
 {
-	gchar *p;
-	gchar *response;
 	gchar *response64;
 	PrefsAccount *ac = session->ac_prefs;
 

--- a/libsylph/pop.c
+++ b/libsylph/pop.c
@@ -250,7 +250,7 @@ gint pop3_getrange_stat_send(Pop3Session *session)
 
 gint pop3_getrange_stat_recv(Pop3Session *session, const gchar *msg)
 {
-	if (sscanf(msg, "%d %lld", &session->count, &session->total_bytes) != 2) {
+	if (sscanf(msg, "%d %" G_GINT64_FORMAT "", &session->count, &session->total_bytes) != 2) {
 		log_warning(_("POP3 protocol error\n"));
 		session->error_val = PS_PROTOCOL;
 		return PS_PROTOCOL;

--- a/libsylph/pop.h
+++ b/libsylph/pop.h
@@ -159,9 +159,17 @@ struct _Pop3Session
 /* #define IDLEN	128 */
 #define IDLEN		POPBUFSIZE
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 Session *pop3_session_new	(PrefsAccount	*account);
 
 GHashTable *pop3_get_uidl_table	(PrefsAccount	*account);
 gint pop3_write_uidl_list	(Pop3Session	*session);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __POP_H__ */

--- a/libsylph/prefs_account.h
+++ b/libsylph/prefs_account.h
@@ -197,6 +197,10 @@ struct _PrefsAccount
 	gint token_expire;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 PrefsAccount *prefs_account_new		(void);
 
 PrefsAccount *prefs_account_get_tmp_prefs	(void);
@@ -209,5 +213,9 @@ void prefs_account_read_config		(PrefsAccount	*ac_prefs,
 void prefs_account_write_config_all	(GList		*account_list);
 
 void prefs_account_free			(PrefsAccount	*ac_prefs);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PREFS_ACCOUNT_H__ */

--- a/libsylph/procheader.h
+++ b/libsylph/procheader.h
@@ -42,6 +42,10 @@ struct _Header
 	gchar *body;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 gint procheader_get_one_field		(gchar		*buf,
 					 size_t		 len,
 					 FILE		*fp,
@@ -97,5 +101,9 @@ stime_t procheader_date_parse		(gchar		*dest,
 void procheader_date_get_localtime	(gchar		*dest,
 					 gint		 len,
 					 const stime_t	 timer);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PROCHEADER_H__ */

--- a/libsylph/procmime.c
+++ b/libsylph/procmime.c
@@ -1890,7 +1890,7 @@ EncodingType procmime_get_encoding_for_text_file(const gchar *file)
 		octet_percentage = 0.0;
 
 	debug_print("procmime_get_encoding_for_text_file(): "
-		    "8bit chars: %d / %d (%f%%)\n", octet_chars, total_len,
+		    "8bit chars: %zd / %zd (%f%%)\n", octet_chars, total_len,
 		    100.0 * octet_percentage);
 
 	if (octet_percentage > 0.20) {
@@ -1926,7 +1926,7 @@ EncodingType procmime_get_encoding_for_str(const gchar *str)
 		octet_percentage = 0.0;
 
 	debug_print("procmime_get_encoding_for_str(): "
-		    "8bit chars: %d / %d (%f%%)\n", octet_chars, total_len,
+		    "8bit chars: %zd / %zd (%f%%)\n", octet_chars, total_len,
 		    100.0 * octet_percentage);
 
 	if (octet_percentage > 0.20) {

--- a/libsylph/procmsg.c
+++ b/libsylph/procmsg.c
@@ -401,7 +401,7 @@ void procmsg_set_flags(GSList *mlist, FolderItem *item)
 	mark_queue_exist = (item->mark_queue != NULL);
 	mark_table = procmsg_read_mark_file(item);
 	if (!mark_table) {
-		item->new = item->unread = item->total = g_slist_length(mlist);
+		item->new_count = item->unread = item->total = g_slist_length(mlist);
 		item->updated = TRUE;
 		item->mark_dirty = TRUE;
 		return;
@@ -452,7 +452,7 @@ void procmsg_set_flags(GSList *mlist, FolderItem *item)
 		++total;
 	}
 
-	item->new = new;
+	item->new_count = new;
 	item->unread = unread;
 	item->total = total;
 	item->unmarked_num = unflagged;
@@ -500,7 +500,7 @@ void procmsg_mark_all_read(FolderItem *item)
 		item->mark_dirty = TRUE;
 	}
 
-	item->new = item->unread = 0;
+	item->new_count = item->unread = 0;
 }
 
 static FolderSortType cmp_func_sort_type;
@@ -834,7 +834,7 @@ gboolean procmsg_flush_folder(FolderItem *item)
 	procmsg_get_mark_sum(item, &n_new, &n_unread, &n_total, &n_min, &n_max,
 			     0);
 	item->unmarked_num = 0;
-	item->new = n_new;
+	item->new_count = n_new;
 	item->unread = n_unread;
 	item->total = n_total;
 
@@ -912,15 +912,15 @@ static void mark_sum_func(gpointer key, gpointer value, gpointer data)
 }
 
 void procmsg_get_mark_sum(FolderItem *item,
-			  gint *new, gint *unread, gint *total,
+			  gint *new_count, gint *unread, gint *total,
 			  gint *min, gint *max,
 			  gint first)
 {
 	GHashTable *mark_table;
 	struct MarkSum marksum;
 
-	*new = *unread = *total = *min = *max = 0;
-	marksum.new    = new;
+	*new_count = *unread = *total = *min = *max = 0;
+	marksum.new    = new_count;
 	marksum.unread = unread;
 	marksum.total  = total;
 	marksum.min    = min;

--- a/libsylph/procmsg.c
+++ b/libsylph/procmsg.c
@@ -542,14 +542,14 @@ GSList *procmsg_sort_msg_list(GSList *mlist, FolderSortKey sort_key,
 	return mlist;
 }
 
-gint procmsg_get_last_num_in_msg_list(GSList *mlist)
+gint procmsg_get_last_num_in_msg_list(const GSList *mlist)
 {
-	GSList *cur;
-	MsgInfo *msginfo;
+	const GSList *cur;
+	const MsgInfo *msginfo;
 	gint last = 0;
 
 	for (cur = mlist; cur != NULL; cur = cur->next) {
-		msginfo = (MsgInfo *)cur->data;
+		msginfo = (const MsgInfo *)cur->data;
 		if (msginfo && msginfo->msgnum > last)
 			last = msginfo->msgnum;
 	}

--- a/libsylph/procmsg.h
+++ b/libsylph/procmsg.h
@@ -220,6 +220,10 @@ struct _MsgEncryptInfo
 typedef FILE * (*DecryptMessageFunc)		(MsgInfo	*msginfo,
 						 MimeInfo      **mimeinfo);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 GHashTable *procmsg_msg_hash_table_create	(GSList		*mlist);
 void procmsg_msg_hash_table_append		(GHashTable	*msg_table,
 						 GSList		*mlist);
@@ -351,5 +355,9 @@ void	 procmsg_msginfo_free		(MsgInfo	*msginfo);
 
 gint procmsg_cmp_msgnum_for_sort	(gconstpointer	 a,
 					 gconstpointer	 b);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PROCMSG_H__ */

--- a/libsylph/procmsg.h
+++ b/libsylph/procmsg.h
@@ -271,7 +271,7 @@ void	procmsg_add_flags		(FolderItem	*item,
 					 MsgFlags	 flags);
 
 void	procmsg_get_mark_sum		(FolderItem	*item,
-					 gint		*new,
+					 gint		*new_count,
 					 gint		*unread,
 					 gint		*total,
 					 gint		*min,

--- a/libsylph/procmsg.h
+++ b/libsylph/procmsg.h
@@ -236,7 +236,7 @@ void	procmsg_mark_all_read		(FolderItem	*item);
 GSList *procmsg_sort_msg_list		(GSList		*mlist,
 					 FolderSortKey	 sort_key,
 					 FolderSortType	 sort_type);
-gint	procmsg_get_last_num_in_msg_list(GSList		*mlist);
+gint	procmsg_get_last_num_in_msg_list(const GSList		*mlist);
 void	procmsg_msg_list_free		(GSList		*mlist);
 
 void	procmsg_write_cache		(MsgInfo	*msginfo,

--- a/libsylph/recv.c
+++ b/libsylph/recv.c
@@ -132,9 +132,9 @@ gint recv_write(SockInfo *sock, FILE *fp)
 	gint count = 0;
 	gint bytes = 0;
 	gchar *p;
-	GTimeVal tv_prev, tv_cur;
+	gint64 tv_prev, tv_cur;
 
-	g_get_current_time(&tv_prev);
+	tv_prev = g_get_real_time();
 
 	for (;;) {
 		if (sock_gets(sock, buf, sizeof(buf)) < 0) {
@@ -153,16 +153,15 @@ gint recv_write(SockInfo *sock, FILE *fp)
 		bytes += len;
 
 		if (recv_ui_func) {
-			g_get_current_time(&tv_cur);
+			tv_cur = g_get_real_time();
 			/* if elapsed time from previous update is greater
 			   than 50msec, update UI */
-			if (tv_cur.tv_sec - tv_prev.tv_sec > 0 ||
-			    tv_cur.tv_usec - tv_prev.tv_usec > UI_REFRESH_INTERVAL) {
+			if (tv_cur - tv_prev > UI_REFRESH_INTERVAL) {
 				gboolean ret;
 				ret = recv_ui_func(sock, count, bytes,
 						   recv_ui_func_data);
 				if (ret == FALSE) return -1;
-				g_get_current_time(&tv_prev);
+				tv_prev = g_get_real_time();
 			}
 		}
 

--- a/libsylph/session.c
+++ b/libsylph/session.c
@@ -336,7 +336,7 @@ gboolean session_is_connected(Session *session)
 		session->state == SESSION_RECV);
 }
 
-SessionErrorValue session_get_error(Session *session)
+SessionErrorValue session_get_error(const Session *session)
 {
 	SessionPrivData *priv;
 

--- a/libsylph/session.c
+++ b/libsylph/session.c
@@ -1008,7 +1008,7 @@ static gboolean session_read_data_as_file_cb(SockInfo *source,
 
 		if (buf_data_len <= PREREAD_SIZE) {
 			if (data_begin_p > session->read_buf) {
-				g_memmove(session->read_buf, data_begin_p,
+				memmove(session->read_buf, data_begin_p,
 					  buf_data_len);
 				data_begin_p = session->read_buf;
 				session->read_buf_p = session->read_buf +
@@ -1039,7 +1039,7 @@ static gboolean session_read_data_as_file_cb(SockInfo *source,
 		}
 		session->read_data_pos += write_len;
 
-		g_memmove(session->read_buf, data_begin_p + write_len,
+		memmove(session->read_buf, data_begin_p + write_len,
 			  PREREAD_SIZE);
 		session->read_buf_p = session->read_buf + PREREAD_SIZE;
 		session->preread_len = PREREAD_SIZE;

--- a/libsylph/session.c
+++ b/libsylph/session.c
@@ -97,7 +97,7 @@ void session_init(Session *session)
 	session->state = SESSION_READY;
 	session->last_access_time = time(NULL);
 
-	g_get_current_time(&session->tv_prev);
+	session->tv_prev = g_get_real_time();
 
 	session->conn_id = 0;
 
@@ -396,17 +396,11 @@ static gboolean session_ping_cb(gpointer data)
 		return FALSE;
 
 	if (session->io_tag > 0 && sock && sock->callback) {
-		GTimeVal tv_cur, tv_result;
+		gint64 tv_cur, tv_result;
 
-		g_get_current_time(&tv_cur);
-		tv_result.tv_sec = tv_cur.tv_sec - session->tv_prev.tv_sec;
-		tv_result.tv_usec = tv_cur.tv_usec - session->tv_prev.tv_usec;
-		if (tv_result.tv_usec < 0) {
-			tv_result.tv_sec--;
-			tv_result.tv_usec += G_USEC_PER_SEC;
-		}
-		if (tv_result.tv_sec * G_USEC_PER_SEC + tv_result.tv_usec >
-		    G_USEC_PER_SEC) {
+		tv_cur = g_get_real_time();
+		tv_result = tv_cur - session->tv_prev;
+		if (tv_result > G_USEC_PER_SEC) {
 			SockFlags save_flags;
 
 			debug_print("state machine freeze for 1 second detected, forcing dispatch.\n");
@@ -599,7 +593,7 @@ gint session_send_data(Session *session, FILE *data_fp, guint size)
 	session->write_data_fp = data_fp;
 	session->write_data_pos = 0;
 	session->write_data_len = size;
-	g_get_current_time(&session->tv_prev);
+	session->tv_prev = g_get_real_time();
 
 #ifdef G_OS_WIN32
 	sock_set_nonblocking_mode(session->sock, FALSE);
@@ -632,7 +626,7 @@ gint session_recv_data(Session *session, guint size, const gchar *terminator)
 
 	g_free(session->read_data_terminator);
 	session->read_data_terminator = g_strdup(terminator);
-	g_get_current_time(&session->tv_prev);
+	session->tv_prev = g_get_real_time();
 
 	if (session->read_buf_len > 0)
 		session->idle_tag = g_idle_add(session_recv_data_idle_cb,
@@ -675,7 +669,7 @@ gint session_recv_data_as_file(Session *session, guint size,
 
 	g_free(session->read_data_terminator);
 	session->read_data_terminator = g_strdup(terminator);
-	g_get_current_time(&session->tv_prev);
+	session->tv_prev = g_get_real_time();
 
 	session->read_data_fp = my_tmpfile();
 	if (!session->read_data_fp) {
@@ -880,17 +874,15 @@ static gboolean session_read_data_cb(SockInfo *source, GIOCondition condition,
 
 	/* incomplete read */
 	if (!complete) {
-		GTimeVal tv_cur;
+		gint64 tv_cur;
 
-		g_get_current_time(&tv_cur);
-		if (tv_cur.tv_sec - session->tv_prev.tv_sec > 0 ||
-		    tv_cur.tv_usec - session->tv_prev.tv_usec >
-		    UI_REFRESH_INTERVAL) {
+		tv_cur = g_get_real_time();
+		if (tv_cur - session->tv_prev > UI_REFRESH_INTERVAL) {
 			if (session->recv_data_progressive_notify)
 				session->recv_data_progressive_notify
 					(session, data_buf->len, 0,
 					 session->recv_data_progressive_notify_data);
-			g_get_current_time(&session->tv_prev);
+			session->tv_prev = g_get_real_time();
 		}
 		return TRUE;
 	}
@@ -1004,7 +996,7 @@ static gboolean session_read_data_as_file_cb(SockInfo *source,
 
 	/* incomplete read */
 	if (!complete) {
-		GTimeVal tv_cur;
+		gint64 tv_cur;
 
 		if (buf_data_len <= PREREAD_SIZE) {
 			if (data_begin_p > session->read_buf) {
@@ -1045,15 +1037,13 @@ static gboolean session_read_data_as_file_cb(SockInfo *source,
 		session->preread_len = PREREAD_SIZE;
 		session->read_buf_len = 0;
 
-		g_get_current_time(&tv_cur);
-		if (tv_cur.tv_sec - session->tv_prev.tv_sec > 0 ||
-		    tv_cur.tv_usec - session->tv_prev.tv_usec >
-		    UI_REFRESH_INTERVAL) {
+		tv_cur = g_get_real_time();
+		if (tv_cur - session->tv_prev > UI_REFRESH_INTERVAL) {
 			if (session->recv_data_progressive_notify)
 				session->recv_data_progressive_notify
 					(session, session->read_data_pos, 0,
 					 session->recv_data_progressive_notify_data);
-			g_get_current_time(&session->tv_prev);
+			session->tv_prev = g_get_real_time();
 		}
 
 		return TRUE;
@@ -1283,12 +1273,10 @@ static gboolean session_write_data_cb(SockInfo *source,
 			priv->error_val = SESSION_ERROR_IO;
 		return FALSE;
 	} else if (ret > 0) {
-		GTimeVal tv_cur;
+		gint64 tv_cur;
 
-		g_get_current_time(&tv_cur);
-		if (tv_cur.tv_sec - session->tv_prev.tv_sec > 0 ||
-		    tv_cur.tv_usec - session->tv_prev.tv_usec >
-		    UI_REFRESH_INTERVAL) {
+		tv_cur = g_get_real_time();
+		if (tv_cur - session->tv_prev > UI_REFRESH_INTERVAL) {
 			session_set_timeout(session, session->timeout_interval);
 			if (session->send_data_progressive_notify)
 				session->send_data_progressive_notify
@@ -1296,7 +1284,7 @@ static gboolean session_write_data_cb(SockInfo *source,
 					 session->write_data_pos,
 					 write_data_len,
 					 session->send_data_progressive_notify_data);
-			g_get_current_time(&session->tv_prev);
+			session->tv_prev = g_get_real_time();
 		}
 		return TRUE;
 	}

--- a/libsylph/session.h
+++ b/libsylph/session.h
@@ -189,6 +189,10 @@ struct _Session
 	gpointer send_data_notify_data;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void session_init		(Session	*session);
 gint session_connect		(Session	*session,
 				 const gchar	*server,
@@ -244,5 +248,9 @@ gint session_recv_data	(Session	*session,
 gint session_recv_data_as_file	(Session	*session,
 				 guint		 size,
 				 const gchar	*terminator);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SESSION_H__ */

--- a/libsylph/session.h
+++ b/libsylph/session.h
@@ -118,7 +118,7 @@ struct _Session
 	SessionState state;
 
 	stime_t last_access_time;
-	GTimeVal tv_prev;
+	gint64 tv_prev;
 
 	gint conn_id;
 

--- a/libsylph/session.h
+++ b/libsylph/session.h
@@ -205,7 +205,7 @@ gint session_disconnect		(Session	*session);
 void session_destroy		(Session	*session);
 gboolean session_is_connected	(Session	*session);
 
-SessionErrorValue session_get_error	(Session	*session);
+SessionErrorValue session_get_error	(const Session	*session);
 
 void session_set_access_time	(Session	*session);
 

--- a/libsylph/socks.h
+++ b/libsylph/socks.h
@@ -44,6 +44,10 @@ struct _SocksInfo
 	gchar *proxy_pass;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SocksInfo *socks_info_new(SocksType type, const gchar *proxy_host,
 			  gushort proxy_port, const gchar *proxy_name,
 			  const gchar *proxy_pass);
@@ -55,5 +59,9 @@ gint socks_connect(SockInfo *sock, const gchar *hostname, gushort port,
 gint socks4_connect(SockInfo *sock, const gchar *hostname, gushort port);
 gint socks5_connect(SockInfo *sock, const gchar *hostname, gushort port,
 		    const gchar *proxy_name, const gchar *proxy_pass);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SOCKS_H__ */

--- a/libsylph/ssl.h
+++ b/libsylph/ssl.h
@@ -51,6 +51,10 @@ typedef gint (*SSLVerifyFunc)		(SockInfo	*sockinfo,
 					 X509		*server_cert,
 					 glong		 verify_result);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ssl_init				(void);
 void ssl_done				(void);
 gboolean ssl_init_socket		(SockInfo	*sockinfo);
@@ -59,6 +63,10 @@ gboolean ssl_init_socket_with_method	(SockInfo	*sockinfo,
 void ssl_done_socket			(SockInfo	*sockinfo);
 
 void ssl_set_verify_func		(SSLVerifyFunc	 func);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* USE_SSL */
 

--- a/libsylph/sylmain.c
+++ b/libsylph/sylmain.c
@@ -48,6 +48,7 @@
 #  include "ssl.h"
 #endif
 
+#ifndef NO_GAPP
 #ifndef PACKAGE
 #  define PACKAGE	GETTEXT_PACKAGE
 #endif
@@ -247,19 +248,6 @@ void syl_init(void)
 #endif
 }
 
-#define MAKE_DIR_IF_NOT_EXIST(dir)					\
-{									\
-	if (!is_dir_exist(dir)) {					\
-		if (is_file_exist(dir)) {				\
-			g_warning("File '%s' already exists. "		\
-				  "Can't create folder.", dir);		\
-			return -1;					\
-		}							\
-		if (make_dir(dir) < 0)					\
-			return -1;					\
-	}								\
-}
-
 void syl_init_gettext(const gchar *package, const gchar *dirname)
 {
 #ifdef ENABLE_NLS
@@ -288,6 +276,20 @@ void syl_init_gettext(const gchar *package, const gchar *dirname)
 
 	bind_textdomain_codeset(package, CS_UTF_8);
 #endif /* ENABLE_NLS */
+}
+#endif /* ! NO_GAPP */
+
+#define MAKE_DIR_IF_NOT_EXIST(dir)					\
+{									\
+	if (!is_dir_exist(dir)) {					\
+		if (is_file_exist(dir)) {				\
+			g_warning("File '%s' already exists. "		\
+				  "Can't create folder.", dir);		\
+			return -1;					\
+		}							\
+		if (make_dir(dir) < 0)					\
+			return -1;					\
+	}								\
 }
 
 gint syl_setup_rc_dir(void)
@@ -328,6 +330,8 @@ void syl_cleanup(void)
 	/* remove temporary files */
 	remove_all_files(get_tmp_dir());
 	remove_all_files(get_mime_tmp_dir());
+
+#ifndef NO_GAPP
 #if GLIB_CHECK_VERSION(2, 6, 0)
 	g_log_set_default_handler(g_log_default_handler, NULL);
 #endif
@@ -339,4 +343,5 @@ void syl_cleanup(void)
 		g_object_unref(app);
 		app = NULL;
 	}
+#endif
 }

--- a/libsylph/sylmain.h
+++ b/libsylph/sylmain.h
@@ -21,6 +21,11 @@
 #define __SYLMAIN_H__
 
 #include <glib.h>
+
+#ifdef NO_GAPP
+#define APP_EMIT(sname)
+#define APP_EMITA(sname, ...)
+#else
 #include <glib-object.h>
 
 /* SylApp object */
@@ -48,10 +53,24 @@ struct _SylAppClass
 GObject *syl_app_create	(void);
 GObject *syl_app_get	(void);
 
+#define APP_EMIT(sname) if (syl_app_get()) \
+	g_signal_emit_by_name(syl_app_get(), sname)
+#define APP_EMITA(sname, ...) if (syl_app_get()) \
+	g_signal_emit_by_name(syl_app_get(), sname, __VA_ARGS__)
+
 void syl_init		(void);
 void syl_init_gettext	(const gchar *package, const gchar *dirname);
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 gint syl_setup_rc_dir	(void);
 void syl_save_all_state	(void);
 void syl_cleanup	(void);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* __SYLMAIN_H__ */

--- a/libsylph/utils.c
+++ b/libsylph/utils.c
@@ -4047,7 +4047,7 @@ static gchar **argv_utf8_to_locale(gchar **argv)
 }
 #endif
 
-gint execute_async(gchar *const argv[])
+gint execute_async(gchar * argv[])
 {
 #if defined(G_OS_WIN32) && !GLIB_CHECK_VERSION(2, 8, 2)
 	gchar **cp_argv;
@@ -4077,7 +4077,7 @@ gint execute_async(gchar *const argv[])
 	return 0;
 }
 
-gint execute_sync(gchar *const argv[])
+gint execute_sync(gchar * argv[])
 {
 	gint status;
 #if defined(G_OS_WIN32) && !GLIB_CHECK_VERSION(2, 8, 2)
@@ -4247,7 +4247,7 @@ gint execute_open_file(const gchar *file, const gchar *content_type)
 		return 0;
 	}
 #elif defined(__APPLE__)
-	const gchar *argv[3] = {"open", NULL, NULL};
+	gchar *argv[3] = {"open", NULL, NULL};
 
 	g_return_val_if_fail(file != NULL, -1);
 
@@ -4256,7 +4256,7 @@ gint execute_open_file(const gchar *file, const gchar *content_type)
 	argv[1] = file;
 	execute_async(argv);
 #else
-	const gchar *argv[3] = {"xdg-open", NULL, NULL};
+	gchar *argv[3] = {"xdg-open", NULL, NULL};
 
 	g_return_val_if_fail(file != NULL, -1);
 

--- a/libsylph/utils.h
+++ b/libsylph/utils.h
@@ -209,6 +209,10 @@ typedef void (*LogFlushFunc)		(void);
 #define Str(x)	#x
 #define Xstr(x)	Str(x)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void list_free_strings		(GList		*list);
 void slist_free_strings		(GSList		*list);
 
@@ -597,5 +601,9 @@ void log_warning	(const gchar *format, ...) G_GNUC_PRINTF(1, 2);
 void log_error		(const gchar *format, ...) G_GNUC_PRINTF(1, 2);
 
 void log_flush		(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UTILS_H__ */

--- a/libsylph/utils.h
+++ b/libsylph/utils.h
@@ -259,8 +259,10 @@ gchar *strtailchomp	(gchar		*str,
 			 gchar		 tail_char);
 gchar *strcrchomp	(gchar		*str);
 
+#ifndef __cplusplus
 gchar *strcasestr	(const gchar	*haystack,
 			 const gchar	*needle);
+#endif
 gpointer my_memmem	(gconstpointer	 haystack,
 			 size_t		 haystacklen,
 			 gconstpointer	 needle,

--- a/libsylph/utils.h
+++ b/libsylph/utils.h
@@ -513,8 +513,8 @@ gchar *file_read_to_str		(const gchar	*file);
 gchar *file_read_stream_to_str	(FILE		*fp);
 
 /* process execution */
-gint execute_async		(gchar *const	 argv[]);
-gint execute_sync		(gchar *const	 argv[]);
+gint execute_async		(gchar *	 argv[]);
+gint execute_sync		(gchar *	 argv[]);
 gint execute_command_line	(const gchar	*cmdline,
 				 gboolean	 async);
 gint execute_command_line_async_wait

--- a/libsylph/virtual.c
+++ b/libsylph/virtual.c
@@ -331,7 +331,7 @@ static GSList *virtual_search_folder(VirtualSearchInfo *info, FolderItem *item)
 	GSList *cur;
 	FilterInfo fltinfo;
 	gint count = 1, total, ncachehit = 0;
-	GTimeVal tv_prev, tv_cur;
+	gint64 tv_prev, tv_cur;
 
 	g_return_val_if_fail(info != NULL, NULL);
 	g_return_val_if_fail(info->rule != NULL, NULL);
@@ -342,7 +342,7 @@ static GSList *virtual_search_folder(VirtualSearchInfo *info, FolderItem *item)
 	if (item->stype == F_VIRTUAL)
 		return NULL;
 
-	g_get_current_time(&tv_prev);
+	tv_prev = g_get_real_time();
 	status_print(_("Searching %s ..."), item->path);
 
 	mlist = folder_item_get_msg_list(item, TRUE);
@@ -358,10 +358,8 @@ static GSList *virtual_search_folder(VirtualSearchInfo *info, FolderItem *item)
 		MsgInfo *msginfo = (MsgInfo *)cur->data;
 		GSList *hlist;
 
-		g_get_current_time(&tv_cur);
-		if (tv_cur.tv_sec > tv_prev.tv_sec ||
-		    tv_cur.tv_usec - tv_prev.tv_usec >
-		    PROGRESS_UPDATE_INTERVAL * 1000) {
+		tv_cur = g_get_real_time();
+		if (tv_cur - tv_prev > PROGRESS_UPDATE_INTERVAL * 1000) {
 			status_print(_("Searching %s (%d / %d)..."),
 				     item->path, count, total);
 			tv_prev = tv_cur;

--- a/libsylph/virtual.c
+++ b/libsylph/virtual.c
@@ -535,7 +535,7 @@ static GSList *virtual_get_msg_list(Folder *folder, FolderItem *item,
 		++total;
 	}
 
-	item->new = new;
+	item->new_count = new;
 	item->unread = unread;
 	item->total = total;
 	item->updated = TRUE;

--- a/libsylph/virtual.c
+++ b/libsylph/virtual.c
@@ -180,9 +180,9 @@ static void virtual_folder_init(Folder *folder, const gchar *name,
 guint sinfo_hash(gconstpointer key)
 {
 	const SearchCacheInfo *sinfo = key;
-	guint h;
+	uintptr_t h;
 
-	h = (guint)sinfo->folder;
+	h = (uintptr_t) sinfo->folder;
 	h ^= sinfo->msgnum;
 	h ^= (guint)sinfo->size;
 	h ^= (guint)sinfo->mtime;
@@ -369,7 +369,7 @@ static GSList *virtual_search_folder(VirtualSearchInfo *info, FolderItem *item)
 		++count;
 
 		if (info->search_cache_table) {
-			gint matched;
+			intptr_t matched;
 			SearchCacheInfo sinfo;
 
 			sinfo.folder = item;
@@ -378,7 +378,7 @@ static GSList *virtual_search_folder(VirtualSearchInfo *info, FolderItem *item)
 			sinfo.mtime = msginfo->mtime;
 			sinfo.flags = msginfo->flags;
 
-			matched = (gint)g_hash_table_lookup
+			matched = (intptr_t) g_hash_table_lookup
 				(info->search_cache_table, &sinfo);
 			if (matched == SCACHE_MATCHED) {
 				match_list = g_slist_prepend

--- a/src/foldersel.c
+++ b/src/foldersel.c
@@ -461,7 +461,7 @@ static void foldersel_append_item(GtkTreeStore *store, FolderItem *item,
 		if (item->total > 0)
 			weight = PANGO_WEIGHT_BOLD;
 	} else {
-		use_color = (item->new > 0);
+		use_color = (item->new_count > 0);
 		if (item->unread > 0)
 			weight = PANGO_WEIGHT_BOLD;
 	}

--- a/src/folderview.c
+++ b/src/folderview.c
@@ -1034,7 +1034,7 @@ gint folderview_check_new(Folder *folder)
 		if (folder && folder != item->folder) continue;
 		if (!folder && FOLDER_IS_REMOTE(item->folder)) continue;
 
-		prev_new = item->new;
+		prev_new = item->new_count;
 		prev_unread = item->unread;
 		folderview_scan_tree_func(item->folder, item, NULL);
 		if (folder_item_scan(item) < 0) {
@@ -1046,8 +1046,8 @@ gint folderview_check_new(Folder *folder)
 		if (item->stype != F_TRASH && item->stype != F_JUNK) {
 			if (prev_unread < item->unread)
 				n_updated += item->unread - prev_unread;
-			else if (prev_new < item->new)
-				n_updated += item->new - prev_new;
+			else if (prev_new < item->new_count)
+				n_updated += item->new_count - prev_new;
 		}
 	}
 
@@ -1094,7 +1094,7 @@ gint folderview_check_new_item(FolderItem *item)
 	gtk_widget_set_sensitive(folderview->treeview, FALSE);
 	GTK_EVENTS_FLUSH();
 
-	prev_new = item->new;
+	prev_new = item->new_count;
 	prev_unread = item->unread;
 	folderview_scan_tree_func(folder, item, NULL);
 	folder_item_scan(item);
@@ -1102,8 +1102,8 @@ gint folderview_check_new_item(FolderItem *item)
 	if (item->stype != F_TRASH && item->stype != F_JUNK) {
 		if (prev_unread < item->unread)
 			n_updated = item->unread - prev_unread;
-		else if (prev_new < item->new)
-			n_updated = item->new - prev_new;
+		else if (prev_new < item->new_count)
+			n_updated = item->new_count - prev_new;
 	}
 
 	gtk_widget_set_sensitive(folderview->treeview, TRUE);
@@ -1154,7 +1154,7 @@ static gboolean folderview_search_new_recursive(GtkTreeModel *model,
 	if (iter) {
 		gtk_tree_model_get(model, iter, COL_FOLDER_ITEM, &item, -1);
 		if (item) {
-			if (item->new > 0 ||
+			if (item->new_count > 0 ||
 			    (item->stype == F_QUEUE && item->total > 0))
 				return TRUE;
 		}
@@ -1364,7 +1364,7 @@ static void folderview_update_row(FolderView *folderview, GtkTreeIter *iter)
 		strcpy(unread_s, "-");
 		strcpy(total_s, "-");
 	} else {
-		itos_buf(new_s, item->new);
+		itos_buf(new_s, item->new_count);
 		itos_buf(unread_s, item->unread);
 		itos_buf(total_s, item->total);
 	}
@@ -1387,7 +1387,7 @@ static void folderview_update_row(FolderView *folderview, GtkTreeIter *iter)
 			weight = PANGO_WEIGHT_BOLD;
 		/* if new messages exist, print with colored letter */
 		use_color =
-			(item->new > 0) ||
+			(item->new_count > 0) ||
 			(add_unread_mark &&
 			 folderview_have_new_children(folderview, iter));
 	}

--- a/src/summaryview.c
+++ b/src/summaryview.c
@@ -2279,7 +2279,7 @@ static void summary_status_show(SummaryView *summaryview)
 	gtk_label_set(GTK_LABEL(summaryview->statlabel_select), str->str);
 	g_string_truncate(str, 0);
 
-	new = summaryview->folder_item->new;
+	new = summaryview->folder_item->new_count;
 	unread = summaryview->folder_item->unread;
 	total = summaryview->folder_item->total;
 	total_size = summaryview->total_size;
@@ -3117,8 +3117,8 @@ static void summary_mark_row_as_read(SummaryView *summaryview,
 	GET_MSG_INFO(msginfo, iter);
 
 	if (MSG_IS_NEW(msginfo->flags)) {
-		if (summaryview->folder_item->new > 0)
-			summaryview->folder_item->new--;
+		if (summaryview->folder_item->new_count > 0)
+			summaryview->folder_item->new_count--;
 		if (summaryview->on_filter && summaryview->flt_new > 0)
 			summaryview->flt_new--;
 		inc_block_notify(TRUE);
@@ -3131,8 +3131,8 @@ static void summary_mark_row_as_read(SummaryView *summaryview,
 	}
 
 	if (summaryview->folder_item->stype == F_VIRTUAL) {
-		if (MSG_IS_NEW(msginfo->flags) && msginfo->folder->new > 0)
-			msginfo->folder->new--;
+		if (MSG_IS_NEW(msginfo->flags) && msginfo->folder->new_count > 0)
+			msginfo->folder->new_count--;
 		if (MSG_IS_UNREAD(msginfo->flags) &&
 		    msginfo->folder->unread > 0)
 			msginfo->folder->unread--;


### PR DESCRIPTION
I'm working on a Qt port of the program and these are the current changes to libsylph which:

- Eliminate compiler warnings.
- Update deprecated GLib items.
- Allow the library to be used with C++.
- Allow use without an application GObject.

The Fedora patch comes from https://src.fedoraproject.org/rpms/sylpheed/tree/.

Nothing here should change the behavior for the Gtk version.  Eventually there will be a few more changes allowing the program name to be changed and the location of the rc directory to be in $HOME/.config.

Any commits that can be pulled from here would be helpful to allow continued sharing of the libsylph code.
