### PR TITLE
Oauth2.0 refresh token support 

### DIFF
--- a/libsylph/imap.c
+++ b/libsylph/imap.c
@@ -3846,15 +3846,14 @@ static gint imap_cmd_auth_oauth2(IMAPSession *session, const gchar *user,
 	gint ok;
 
 	account = (PrefsAccount *)(SESSION(session)->data);
-	if (!account->token)
-		oauth2_get_token(user, &account->token, NULL, NULL);
+	oauth2_get_token(user, &account->token, &account->expires_at);
 	if (!account->token) {
 		log_warning("Could not get OAuth2 token.\n");
 		return IMAP_AUTHFAIL;
 	}
 
 	response64 = oauth2_get_sasl_xoauth2(user, account->token);
-	log_print("IMAP4> %s\n", response64);
+	log_print("IMAP4> <sasl xoauth2 ********>\n");
 	sock_puts(SESSION(session)->sock, response64);
 	ok = imap_cmd_ok(session, NULL);
 	if (ok != IMAP_SUCCESS) {

--- a/libsylph/oauth2.c
+++ b/libsylph/oauth2.c
@@ -36,33 +36,61 @@
 
 gint oauth2_get_token   (const gchar     *user,
                          gchar          **token,
-                         gchar          **r_token,
-                         gint            *expire)
+                         time_t          *expires_at)
 {
 	gchar *argv[] = {"syl-auth-helper", NULL, NULL};
 	gchar *out = NULL;
+	gchar *err = NULL;
 	gint status = 0;
 	GError *error = NULL;
 
 	g_return_val_if_fail(user != NULL, -1);
 
+	debug_print("Current time = %ld, oauth2 token expires_at = %ld\n", time(NULL), *expires_at);
+	if (*token) {
+		if (expires_at && *expires_at && time(NULL) < *expires_at-60) {
+			debug_print("OAuth2 token present and not yet expired.\n");
+			return 0;
+		} else {
+			debug_print("OAuth2 token present and expired, or about to expire within 60s, going to refresh it by running syl-auth-helper.\n");
+		}
+	} else {
+		debug_print("OAuth2 token not present, going to obtain it by running syl-auth-helper.\n");
+	}
+
 	argv[1] = (gchar *)user;
 	if (g_spawn_sync(NULL, argv, NULL, G_SPAWN_SEARCH_PATH,
-			 NULL, NULL, &out, NULL, &status, &error)) {
-		debug_print("syl-auth-helper out: %s\n", out);
+			 NULL, NULL, &out, &err, &status, &error)) {
+		//debug_print("syl-auth-helper out: %s\n", out); //contains access token, do not uncomment and show this output to anyone else.
 		gchar **lines = g_strsplit(out, "\n", 4);
 		if (lines && lines[0] && token) {
 			*token = g_strdup(g_strchomp(lines[0]));
-			if (lines[1] && r_token)
-				*r_token = g_strdup(g_strchomp(lines[1]));
+			if (lines[1] && expires_at) {
+				*expires_at = atol(g_strchomp(lines[1]));
+				debug_print("got token from OAuth2 helper, current unix time %ld, expires_at unix time %ld\n", time(NULL), *expires_at);
+			} else {
+				g_warning("got token from OAuth2 helper but no expiry time on 2nd line\n");
+			}
+			if (strlen(err) > 0) {
+				g_warning("syl-auth-helper returned a token but also gave these errors:\n%s",err);
+			}
+		} else {
+			if (strlen(err) > 0) {
+				g_warning("syl-auth-helper did not return a token and gave these errors:\n%s",err);
+			} else {
+				g_warning("syl-auth-helper returned nothing, try running it manually with --debug for more info.\n");
+			}
 		}
 		g_strfreev(lines);
-		return 0;
 	} else {
-		g_warning("OAuth2 helper execution failed.\n");
-		g_error_free(error);
-		return -1;
+		g_warning("OAuth2 helper execution failed, error: %s\n", (error && error->message) ? error->message : "null");
 	}
+	if (error) {
+		g_error_free(error);
+	}
+	g_free(out);
+	g_free(err);
+	return 0;
 }
 
 gchar *oauth2_get_sasl_xoauth2	(const gchar	 *user,

--- a/libsylph/oauth2.h
+++ b/libsylph/oauth2.h
@@ -28,8 +28,7 @@
 
 gint oauth2_get_token		(const gchar	 *user,
 				 gchar		**token,
-				 gchar		**r_token,
-				 gint		 *expire);
+				 time_t          *expires_at);
 gchar *oauth2_get_sasl_xoauth2	(const gchar	 *user,
 				 const gchar	 *token);
 

--- a/libsylph/pop.c
+++ b/libsylph/pop.c
@@ -226,8 +226,7 @@ gint pop3_getauth_auth_data_send(Pop3Session *session)
 
 	session->state = POP3_GETAUTH_AUTH_DATA;
 
-	if (!ac->token)
-		oauth2_get_token(session->user, &ac->token, NULL, NULL);
+	oauth2_get_token(session->user, &ac->token, &ac->expires_at);
 	if (!ac->token) {
 		log_warning("Could not get OAuth2 token.\n");
 		session->error_val = PS_AUTHFAIL;

--- a/libsylph/prefs_account.h
+++ b/libsylph/prefs_account.h
@@ -193,8 +193,7 @@ struct _PrefsAccount
 
 	/* OAuth2 token */
 	gchar *token;
-	gchar *refresh_token;
-	gint token_expire;
+	time_t expires_at;
 };
 
 PrefsAccount *prefs_account_new		(void);

--- a/libsylph/smtp.c
+++ b/libsylph/smtp.c
@@ -245,9 +245,8 @@ static gint smtp_auth_recv(SMTPSession *session, const gchar *msg)
 		if (!strncmp(msg, "334 ", 4)) {
 			gchar *response64;
 			PrefsAccount *ac = (PrefsAccount *)SESSION(session)->data;
-			if (ac && !ac->token)
-				oauth2_get_token(session->user, &ac->token, NULL, NULL);
-			if (!ac || !ac->token) {
+			oauth2_get_token(session->user, &ac->token, &ac->expires_at);
+			if (!ac->token) {
 				log_warning("Could not get OAuth2 token.\n");
 				session_send_msg(SESSION(session), SESSION_MSG_NORMAL, "*");
 				log_print("ESMTP> *\n");
@@ -257,7 +256,7 @@ static gint smtp_auth_recv(SMTPSession *session, const gchar *msg)
 			response64 = oauth2_get_sasl_xoauth2(session->user, ac->token);
 			session_send_msg(SESSION(session), SESSION_MSG_NORMAL,
 					 response64);
-			log_print("ESMTP> %s\n", response64);
+			log_print("ESMTP> <sasl xoauth2 ********>\n");
 			g_free(response64);
 		}
 		break;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -172,6 +172,7 @@ sylpheed_LDADD = \
 syl_auth_helper_LDADD = \
 	$(GLIB_LIBS) \
 	$(LIBICONV) \
+	$(GPGME_LIBS) \
 	$(CURL_LIBS) \
 	../libsylph/libsylph-0.la
 

--- a/src/syl-auth-helper.c
+++ b/src/syl-auth-helper.c
@@ -48,6 +48,7 @@ typedef struct _APIInfo
 	gchar *client_secret;
 	gchar *scope;
 	gint local_port;
+	gint use_pkce;
 } APIInfo;
 
 typedef struct _TokenData
@@ -343,6 +344,7 @@ static APIInfo *get_api_info(GKeyFile *key_file, const gchar *address)
 		api->local_port = g_key_file_get_integer(key_file, group, "local_port", NULL);
 		if (api->local_port == 0)
 			api->local_port = 8089;
+		api->use_pkce = g_key_file_get_integer(key_file, group, "use_pkce", NULL);
 	}
 
 	g_strfreev(groups);
@@ -411,6 +413,34 @@ static gchar *generate_state()
 	return str;
 }
 
+static gchar *generate_challenge(char* verifier)
+{
+	GChecksum *checksum = g_checksum_new(G_CHECKSUM_SHA256);
+	gsize *checksum_len = malloc(sizeof(gsize));
+	*checksum_len = 32; //sha256 is 32 bytes
+	guint8 *checksum_dest = malloc(*checksum_len);
+	gchar *str;
+	g_checksum_update(checksum, (const guchar*)verifier, strlen(verifier));
+	g_checksum_get_digest(checksum, checksum_dest, checksum_len);
+	g_checksum_free(checksum);
+	str = g_malloc(*checksum_len * 2 + 1);
+	base64_encode(str, checksum_dest, *checksum_len);
+	free(checksum_len);
+	free(checksum_dest);
+	/* convert to Base64 URL encoding */
+	for (int i = 0; str[i] != '\0'; i++) {
+		if (str[i] == '+')
+			str[i] = '-';
+		else if (str[i] == '/')
+			str[i] = '_';
+		else if (str[i] == '=') {
+			str[i] = '\0';
+			break;
+		}
+	}
+	return str;
+}
+
 int main(int argc, char *argv[])
 {
 	int ret = EXIT_SUCCESS;
@@ -428,6 +458,8 @@ int main(int argc, char *argv[])
 	gint i;
 	const gchar *address = NULL;
 	APIInfo *api;
+	gchar *code_challenge = NULL;
+	gchar *code_verifier = NULL;
 
 	key_file = g_key_file_new();
 	file = g_strconcat(get_rc_dir(), G_DIR_SEPARATOR_S, "oauth2.ini", NULL);
@@ -482,6 +514,15 @@ int main(int argc, char *argv[])
 	g_string_append_printf(auth_uri, "&state=%s", state);
 	g_string_append(auth_uri, "&access_type=offline");
 
+	if (api->use_pkce) {
+		g_string_append(auth_uri, "&code_challenge_method=S256");
+		code_verifier = generate_state();
+		debug_print("code_verifier =>%s<=\n",code_verifier);
+		code_challenge = generate_challenge(code_verifier);
+		debug_print("code_challenge =>%s<=\n",code_challenge);
+		g_string_append_printf(auth_uri, "&code_challenge=%s",code_challenge);
+		free(code_challenge);
+	}
 	debug_print("url: %s\n", auth_uri->str);
 	//chromium prints "Opening in existing browser session." on
 	//stdout, which must be prevented from appearing on this
@@ -513,6 +554,10 @@ int main(int argc, char *argv[])
 	tmp = curl_easy_escape(curl, api->redirect_uri, 0);
 	g_string_append_printf(req_body, "&redirect_uri=%s", tmp);
 	curl_free(tmp);
+	if (api->use_pkce) {
+		g_string_append_printf(req_body, "&code_verifier=%s",code_verifier);
+		free(code_verifier);
+	}
 	g_string_append(req_body, "&grant_type=authorization_code");
 	if (api->client_secret) {
 		tmp = curl_easy_escape(curl, api->client_secret, 0);

--- a/src/syl-auth-helper.c
+++ b/src/syl-auth-helper.c
@@ -514,9 +514,11 @@ int main(int argc, char *argv[])
 	g_string_append_printf(req_body, "&redirect_uri=%s", tmp);
 	curl_free(tmp);
 	g_string_append(req_body, "&grant_type=authorization_code");
-	tmp = curl_easy_escape(curl, api->client_secret, 0);
-	g_string_append_printf(req_body, "&client_secret=%s", tmp);
-	curl_free(tmp);
+	if (api->client_secret) {
+		tmp = curl_easy_escape(curl, api->client_secret, 0);
+		g_string_append_printf(req_body, "&client_secret=%s", tmp);
+		curl_free(tmp);
+	}
 
 	body = http_post(api->token_uri, req_body->str, &header);
 	if (!header && !body) {

--- a/src/syl-auth-helper.c
+++ b/src/syl-auth-helper.c
@@ -483,7 +483,16 @@ int main(int argc, char *argv[])
 	g_string_append(auth_uri, "&access_type=offline");
 
 	debug_print("url: %s\n", auth_uri->str);
+	//chromium prints "Opening in existing browser session." on
+	//stdout, which must be prevented from appearing on this
+	//program's stdout, because later the token will be printed
+	//on stdout.
+	int original_stdout_fd = dup(fileno(stdout));
+	freopen("/dev/null", "w", stdout);
 	open_uri(auth_uri->str, NULL);
+	dup2(original_stdout_fd, fileno(stdout));
+	close(original_stdout_fd);
+	//freopen("CON", "w", stdout);//for windows, needs testing
 	g_string_free(auth_uri, TRUE);
 
 	code = http_redirect_accept(api->local_port, state);

--- a/src/syl-auth-helper.c
+++ b/src/syl-auth-helper.c
@@ -26,11 +26,13 @@
 #include <curl/curl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gpgme.h>
 #ifdef G_OS_WIN32
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
 #else
 #  include <sys/socket.h>
+#  include <sys/file.h>
 #endif /* G_OS_WIN32 */
 
 #include "utils.h"
@@ -49,11 +51,13 @@ typedef struct _APIInfo
 	gchar *scope;
 	gint local_port;
 	gint use_pkce;
+	gchar *gpg_key_id;
 } APIInfo;
 
 typedef struct _TokenData
 {
 	gint expires_in;
+	time_t expires_at;
 	gint ext_expires_in;
 	gchar *access_token;
 	gchar *refresh_token;
@@ -71,6 +75,19 @@ static AcceptData accept_data = {
 	NULL,
 	NULL
 };
+
+typedef struct _GpgGlobals
+{
+	gpgme_ctx_t gpg_ctx;
+	gpgme_key_t recipient_key[2];
+	gchar *gpg_key_id;
+	gchar *oauth_creds_file;
+} GpgGlobals;
+
+static GpgGlobals gpg_globals;
+
+static char *lock_file_path;
+static int lock_fd;
 
 static gchar *http_get(const gchar *url, gchar **r_header);
 static gchar *http_post(const gchar *url, const gchar *req_body, gchar **r_header);
@@ -267,7 +284,7 @@ static gchar *http_post(const gchar *url, const gchar *req_body, gchar **r_heade
 #endif
 
 	debug_print("http_post: url: %s\n", url);
-	debug_print("http_post: body: %s\n", req_body);
+	//debug_print("http_post: body: %s\n", req_body); //contains refresh token which grants access to your email, do not uncomment and show this output to anyone else.
 
 	curl = curl_easy_init();
 	if (!curl) {
@@ -345,6 +362,7 @@ static APIInfo *get_api_info(GKeyFile *key_file, const gchar *address)
 		if (api->local_port == 0)
 			api->local_port = 8089;
 		api->use_pkce = g_key_file_get_integer(key_file, group, "use_pkce", NULL);
+		api->gpg_key_id = g_key_file_get_string(key_file, group, "gpg_key_id", NULL);
 	}
 
 	g_strfreev(groups);
@@ -372,18 +390,64 @@ static gint parse_token_response(const gchar *body, TokenData *data)
 	data->access_token = g_strndup(p, e - p);
 
 	p = strstr(body, "\"refresh_token\"");
-	if (!p) return 0;
+	if (!p) return -1;
 	p += 15;
 	p = strchr(p, ':');
-	if (!p) return 0;
+	if (!p) return -1;
 	p++;
 	p = strchr(p, '\"');
-	if (!p) return 0;
+	if (!p) return -1;
 	p++;
 	e = strchr(p, '\"');
-	if (!e) return 0;
+	if (!e) return -1;
 	data->refresh_token = g_strndup(p, e - p);
 
+	p = strstr(body, "\"expires_in\"");
+	if (!p) return -1;
+	p += 12;
+	p = strchr(p, ':');
+	if (!p) return -1;
+	p++;
+	e = strchr(p, ',');
+	if (!e) {
+		e = strchr(p, '}');
+	}
+	if (!e) return -1;
+	char * tmp = g_strndup(p, e - p);
+	data->expires_in = atol(tmp);
+	free(tmp);
+	data->expires_at = time(NULL) + data->expires_in;
+	debug_print ("parsed oauth token from http response, expires in %d seconds from now, at unix time %lu\n", data->expires_in, data->expires_at);
+	return 0;
+}
+
+static gint parse_token_file(const gchar *body, TokenData *data)
+{
+	//format is:
+	//line1: access token
+	//line2: refresh_token
+	//line3: unix time expiry
+	const gchar *p, *e;
+
+	//could rewrite using g_strsplit.
+	if (!body || !data) return -1;
+	p=body;
+	e = strstr(body, "\n");
+	if (!e) return -1;
+	data->access_token = g_strndup(p, e - p);
+	p = e+1;
+
+	e = strstr(p, "\n");
+	if (!e) return -1;
+	data->refresh_token = g_strndup(p, e - p);
+	p = e+1;
+
+	e = strstr(p, "\n");
+	if (!e) return -1;
+	char * tmp = g_strndup(p, e - p);
+	data->expires_at = atol(tmp);
+	free (tmp);
+	debug_print ("got OAuth token from storage, expires at unix time %ld\n", data->expires_at);
 	return 0;
 }
 
@@ -441,6 +505,197 @@ static gchar *generate_challenge(char* verifier)
 	return str;
 }
 
+#define fail_if_err(gpg_err)						\
+	do {								\
+		if (gpg_err) {						\
+			fprintf(stderr, "%s:%d: %s: %s\n",		\
+				__FILE__, __LINE__, gpgme_strsource(gpg_err), gpgme_strerror(gpg_err)); \
+			exit(1);					\
+		}							\
+	} while (0)
+
+//Returns:
+//True if token is present and needs refresh,
+//False if token isn't present and need to obtain a new one,
+//Exits if present and doesn't need refresh.
+gboolean get_creds_from_storage(TokenData *data)
+{
+	gpgme_error_t gpg_err;
+	gpgme_data_t gpg_data_crypt;
+	gpgme_data_t gpg_data_plain;
+	const size_t read_size = 4096;
+	gchar *oauth_creds_plain_buffer;
+	size_t oauth_creds_plain_buffer_sz = read_size;
+	size_t total_read;
+	ssize_t bytes_read;
+	gboolean ret;
+
+	struct stat fileStat;
+	if (stat(gpg_globals.oauth_creds_file, &fileStat) == 0) {
+		// Check if others have read permission, they should not.
+		if ((fileStat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO)) != (S_IRUSR|S_IWUSR)) {
+			fprintf(stderr, "Permissions for %s are not -rw-------.\n", gpg_globals.oauth_creds_file);
+			exit(-1);
+		}
+		gpg_err = gpgme_data_new_from_file(&gpg_data_crypt, gpg_globals.oauth_creds_file, 1);
+		fail_if_err(gpg_err);
+		gpg_err = gpgme_data_new(&gpg_data_plain);
+		fail_if_err(gpg_err);
+		gpg_err = gpgme_op_decrypt(gpg_globals.gpg_ctx, gpg_data_crypt, gpg_data_plain);
+		fail_if_err(gpg_err);
+		gpgme_data_seek(gpg_data_plain, 0, SEEK_SET);
+		oauth_creds_plain_buffer = malloc (oauth_creds_plain_buffer_sz);
+		total_read = 0;
+		while (1) {
+			bytes_read = gpgme_data_read(gpg_data_plain, oauth_creds_plain_buffer+total_read, read_size);
+			total_read += bytes_read;
+			if (bytes_read < 0) {
+				fprintf(stderr, "gpgme_data_read on file %s returned %lu\n", gpg_globals.oauth_creds_file, bytes_read);
+				free (oauth_creds_plain_buffer);
+				exit (-1);
+			}
+			if (bytes_read == 0) {
+				break;
+			}
+			oauth_creds_plain_buffer_sz += read_size;
+			oauth_creds_plain_buffer = realloc (oauth_creds_plain_buffer, oauth_creds_plain_buffer_sz);
+		}
+		if (parse_token_file(oauth_creds_plain_buffer, data) != 0) {
+			fprintf(stderr, "File %s exists but failed to parse it.\n", gpg_globals.oauth_creds_file);
+			//fprintf(stderr, "raw data in file (do not show this to anyone as it may grant access to your email): \n%s\n\n", oauth_creds_plain_buffer);
+			free (oauth_creds_plain_buffer);
+			exit (-1);
+		}
+		free (oauth_creds_plain_buffer);
+		if (data->expires_at && time(NULL) < data->expires_at-60) {
+			debug_print("access token found in %s hasn't expired yet, returning it without refresh.\n", gpg_globals.oauth_creds_file);
+			printf ("%s\n%lu\n", data->access_token, (uint64_t)data->expires_at);
+			gpgme_data_release(gpg_data_crypt);
+			gpgme_data_release(gpg_data_plain);
+			gpgme_release(gpg_globals.gpg_ctx);
+			free(data->access_token);
+			free(data->refresh_token);
+			exit(0);
+		} else {
+			debug_print("access token found in %s has expired or is about to soon, refreshing it.\n", gpg_globals.oauth_creds_file);
+			free(data->access_token);
+			if  (!lock_file_path) {
+				//On 1st call, lock_file_path isn't defined,
+				//and this will be called again after
+				//lock_file_path is set, so free
+				//refresh_token now, otherwise it leaks.
+				free(data->refresh_token);
+			}
+			ret = TRUE;
+		}
+		gpgme_data_release(gpg_data_crypt);
+		gpgme_data_release(gpg_data_plain);
+	} else {
+		debug_print("OAuth creds file %s not found, doing initial auth flow and will create it if successful.\n", gpg_globals.oauth_creds_file);
+		ret = FALSE;
+	}
+	return ret;
+}
+
+void save_creds_to_storage(TokenData *data)
+{
+	gpgme_error_t gpg_err;
+	gpgme_data_t gpg_data_crypt;
+	gpgme_data_t gpg_data_plain;
+	const size_t read_size = 4096;
+	gchar *oauth_creds_plain_buffer;
+	size_t oauth_creds_plain_buffer_sz;
+	gchar *oauth_creds_crypt_buffer;
+	size_t oauth_creds_crypt_buffer_sz = read_size;
+	size_t total_read;
+	ssize_t bytes_read;
+
+	oauth_creds_plain_buffer_sz = strlen(data->access_token) + strlen(data->refresh_token) + 20;
+	oauth_creds_plain_buffer = malloc (oauth_creds_plain_buffer_sz);
+	sprintf (oauth_creds_plain_buffer, "%s\n%s\n%lu\n", data->access_token, data->refresh_token, (uint64_t)data->expires_at);
+	free(data->refresh_token);
+	gpg_err = gpgme_data_new_from_mem(&gpg_data_plain, oauth_creds_plain_buffer, strlen(oauth_creds_plain_buffer), 0);
+	fail_if_err(gpg_err);
+	gpg_err = gpgme_data_new(&gpg_data_crypt);
+	fail_if_err(gpg_err);
+	gpg_err = gpgme_op_encrypt(gpg_globals.gpg_ctx, gpg_globals.recipient_key, GPGME_ENCRYPT_ALWAYS_TRUST, gpg_data_plain, gpg_data_crypt);
+	fail_if_err(gpg_err);
+	gpgme_key_unref(gpg_globals.recipient_key[0]);
+	//In gpgme 1.24.0 and later can use gpgme_data_set_file_name(gpg_data_crypt, oauth_creds_file) instead of all the following:
+	gpgme_data_seek(gpg_data_crypt, 0, SEEK_SET);
+	oauth_creds_crypt_buffer = malloc (oauth_creds_crypt_buffer_sz);
+	total_read = 0;
+	while (1) {
+		bytes_read = gpgme_data_read(gpg_data_crypt, oauth_creds_crypt_buffer+total_read, read_size);
+		total_read += bytes_read;
+		if (bytes_read < 0) {
+			fprintf(stderr, "gpgme_data_read on encrypted data in mem returned %ld\n", bytes_read);
+			free (oauth_creds_crypt_buffer);
+			gpgme_data_release(gpg_data_crypt);
+			gpgme_data_release(gpg_data_plain);
+			gpgme_release(gpg_globals.gpg_ctx);
+			exit (-1);
+		}
+		if (bytes_read == 0) {
+			break;
+		}
+		oauth_creds_crypt_buffer_sz += read_size;
+		oauth_creds_crypt_buffer = realloc (oauth_creds_crypt_buffer, oauth_creds_crypt_buffer_sz);
+	}
+	gpgme_data_release(gpg_data_crypt);
+	gpgme_data_release(gpg_data_plain);
+	free(oauth_creds_plain_buffer);
+	unlink (gpg_globals.oauth_creds_file);
+	umask(0077);
+	FILE *fp;
+	fp = fopen(gpg_globals.oauth_creds_file, "w");
+	if (fp == NULL) {
+		int saved_errno = errno;
+		fprintf(stderr, "Error opening file %s to save the token: ", gpg_globals.oauth_creds_file);
+		errno = saved_errno;
+		perror(NULL);
+		exit (-1);
+	}
+	if (fwrite(oauth_creds_crypt_buffer, 1, total_read, fp) != total_read) {
+		int saved_errno = errno;
+		fprintf(stderr, "Error writing encrypted token to file %s: ", gpg_globals.oauth_creds_file);
+		errno = saved_errno;
+		perror(NULL);
+		exit (-1);
+	}
+	fclose(fp);
+	free(oauth_creds_crypt_buffer);
+}
+
+int lock_for_single_instance(){
+	int fd = open(lock_file_path, O_CREAT | O_RDWR, 0666);
+	if (fd == -1) {
+		int saved_errno = errno;
+		fprintf(stderr, "Error opening lock file %s\n", lock_file_path);
+		errno = saved_errno;
+		perror(NULL);
+		exit(-1);
+	}
+	debug_print("calling flock on %s\n",lock_file_path);
+	if (flock(fd, LOCK_EX) == -1) {
+		int saved_errno = errno;
+		fprintf(stderr, "Error acquiring file lock on file %s\n", lock_file_path);
+		errno = saved_errno;
+		perror(NULL);
+		exit(-1);
+	}
+	debug_print("got lock\n");
+	return fd;
+}
+
+static void unlock (){
+	debug_print("unlocking, removing lock file %s\n", lock_file_path);
+	flock(lock_fd, LOCK_UN);
+	close(lock_fd);
+	unlink(lock_file_path);
+	free(lock_file_path);
+}
+
 int main(int argc, char *argv[])
 {
 	int ret = EXIT_SUCCESS;
@@ -454,12 +709,13 @@ int main(int argc, char *argv[])
 	GString *req_body;
 	GKeyFile *key_file;
 	gchar *file;
-	TokenData data = {0, 0, NULL, NULL};
+	TokenData data = {0, 0, 0, NULL, NULL};
 	gint i;
 	const gchar *address = NULL;
 	APIInfo *api;
 	gchar *code_challenge = NULL;
 	gchar *code_verifier = NULL;
+	gboolean refresh = FALSE;
 
 	key_file = g_key_file_new();
 	file = g_strconcat(get_rc_dir(), G_DIR_SEPARATOR_S, "oauth2.ini", NULL);
@@ -489,10 +745,45 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 	api = get_api_info(key_file, address);
+	g_key_file_free(key_file);
 	if (!api) {
 		g_warning("could not get API info");
 		return EXIT_FAILURE;
 	}
+
+	if (api->gpg_key_id) {
+		gpg_globals.gpg_key_id = api->gpg_key_id;
+	} else {
+		gpg_globals.gpg_key_id = (char*)address;
+	}
+	debug_print("Will use gpg key with id %s for token storage.\n", gpg_globals.gpg_key_id);
+	gpg_globals.oauth_creds_file = g_strconcat(get_rc_dir(), G_DIR_SEPARATOR_S, "oauth_credentials_", address, ".gpg", NULL);
+	gpgme_check_version(NULL);
+	gpgme_error_t gpg_err;
+	gpg_err = gpgme_new(&gpg_globals.gpg_ctx);
+	fail_if_err(gpg_err);
+	gpgme_set_textmode(gpg_globals.gpg_ctx, 1);
+	gpg_err = gpgme_get_key(gpg_globals.gpg_ctx, gpg_globals.gpg_key_id, gpg_globals.recipient_key, 1);
+	gpgme_err_code_t gpgme_code = gpgme_err_code(gpg_err);
+	if (gpgme_code == GPG_ERR_EOF) {
+		fprintf(stderr, "Failed to find gpg key with secret key for id %s.  You must have this (your own key with secret), or generate a new one, or set gpg_key_id in oauth2.ini to an existing one, to be able to decrypt the token which will be stored encrypted for this account.\n", gpg_globals.gpg_key_id);
+		gpgme_release(gpg_globals.gpg_ctx);
+		exit (-1);
+	} else {
+		fail_if_err(gpg_err);
+	}
+	gpg_globals.recipient_key[1] = NULL; // Null-terminate the array
+
+	refresh = get_creds_from_storage(&data);
+
+	lock_file_path = malloc (strlen(gpg_globals.oauth_creds_file) + 6);
+	sprintf(lock_file_path, "%s.lock",gpg_globals.oauth_creds_file);
+	lock_fd = lock_for_single_instance();
+	atexit(unlock);
+
+	//call it again because if another instance got the lock and updated
+	//it, then this will now just output it and exit.
+	refresh = get_creds_from_storage(&data);
 
 	curl_global_init(CURL_GLOBAL_ALL);
 
@@ -501,64 +792,69 @@ int main(int argc, char *argv[])
 		curl_global_cleanup();
 		return EXIT_FAILURE;
 	}
-	auth_uri = g_string_new(api->auth_uri);
-	g_string_append(auth_uri, "?response_type=code");
-	g_string_append_printf(auth_uri, "&client_id=%s", api->client_id);
-	tmp = curl_easy_escape(curl, api->redirect_uri, 0);
-	g_string_append_printf(auth_uri, "&redirect_uri=%s", tmp);
-	curl_free(tmp);
-	tmp = curl_easy_escape(curl, api->scope, 0);
-	g_string_append_printf(auth_uri, "&scope=%s", tmp);
-	curl_free(tmp);
-	state = generate_state();
-	g_string_append_printf(auth_uri, "&state=%s", state);
-	g_string_append(auth_uri, "&access_type=offline");
+	if (!refresh) {
+		auth_uri = g_string_new(api->auth_uri);
+		g_string_append(auth_uri, "?response_type=code");
+		g_string_append_printf(auth_uri, "&client_id=%s", api->client_id);
+		tmp = curl_easy_escape(curl, api->redirect_uri, 0);
+		g_string_append_printf(auth_uri, "&redirect_uri=%s", tmp);
+		curl_free(tmp);
+		tmp = curl_easy_escape(curl, api->scope, 0);
+		g_string_append_printf(auth_uri, "&scope=%s", tmp);
+		curl_free(tmp);
+		state = generate_state();
+		g_string_append_printf(auth_uri, "&state=%s", state);
+		g_string_append(auth_uri, "&access_type=offline");
 
-	if (api->use_pkce) {
-		g_string_append(auth_uri, "&code_challenge_method=S256");
-		code_verifier = generate_state();
-		debug_print("code_verifier =>%s<=\n",code_verifier);
-		code_challenge = generate_challenge(code_verifier);
-		debug_print("code_challenge =>%s<=\n",code_challenge);
-		g_string_append_printf(auth_uri, "&code_challenge=%s",code_challenge);
-		free(code_challenge);
+		if (api->use_pkce) {
+			g_string_append(auth_uri, "&code_challenge_method=S256");
+			code_verifier = generate_state();
+			debug_print("code_verifier =>%s<=\n",code_verifier);
+			code_challenge = generate_challenge(code_verifier);
+			debug_print("code_challenge =>%s<=\n",code_challenge);
+			g_string_append_printf(auth_uri, "&code_challenge=%s",code_challenge);
+			free(code_challenge);
+		}
+		debug_print("url: %s\n", auth_uri->str);
+		//chromium prints "Opening in existing browser session." on
+		//stdout, which must be prevented from appearing on this
+		//program's stdout, because later the token will be printed
+		//on stdout.
+		int original_stdout_fd = dup(fileno(stdout));
+		freopen("/dev/null", "w", stdout);
+		open_uri(auth_uri->str, NULL);
+		dup2(original_stdout_fd, fileno(stdout));
+		close(original_stdout_fd);
+		//freopen("CON", "w", stdout);//for windows, needs testing
+		g_string_free(auth_uri, TRUE);
+		code = http_redirect_accept(api->local_port, state);
+		g_free(state);
+		if (!code) {
+			curl_easy_cleanup(curl);
+			curl_global_cleanup();
+			return EXIT_FAILURE;
+		}
+		//debug_print("code: %s\n",code); //possibly allows access to your account, do not uncomment and show this output to anyone else.
 	}
-	debug_print("url: %s\n", auth_uri->str);
-	//chromium prints "Opening in existing browser session." on
-	//stdout, which must be prevented from appearing on this
-	//program's stdout, because later the token will be printed
-	//on stdout.
-	int original_stdout_fd = dup(fileno(stdout));
-	freopen("/dev/null", "w", stdout);
-	open_uri(auth_uri->str, NULL);
-	dup2(original_stdout_fd, fileno(stdout));
-	close(original_stdout_fd);
-	//freopen("CON", "w", stdout);//for windows, needs testing
-	g_string_free(auth_uri, TRUE);
-
-	code = http_redirect_accept(api->local_port, state);
-	if (!code) {
-		curl_easy_cleanup(curl);
-		curl_global_cleanup();
-		return EXIT_FAILURE;
-	}
-	debug_print("code: %s\n",code);
 
 	req_body = g_string_new(NULL);
 	g_string_append_printf(req_body, "client_id=%s", api->client_id);
-	tmp = curl_easy_escape(curl, api->scope, 0);
-	g_string_append_printf(req_body, "&scope=%s", tmp);
-	curl_free(tmp);
-	g_string_append_printf(req_body, "&state=%s", state);
-	g_string_append_printf(req_body, "&code=%s", code);
-	tmp = curl_easy_escape(curl, api->redirect_uri, 0);
-	g_string_append_printf(req_body, "&redirect_uri=%s", tmp);
-	curl_free(tmp);
-	if (api->use_pkce) {
-		g_string_append_printf(req_body, "&code_verifier=%s",code_verifier);
-		free(code_verifier);
+	if (!refresh){
+		g_string_append_printf(req_body, "&code=%s", code);
+		g_free(code);
+		tmp = curl_easy_escape(curl, api->redirect_uri, 0);
+		g_string_append_printf(req_body, "&redirect_uri=%s", tmp);
+		curl_free(tmp);
+		g_string_append(req_body, "&grant_type=authorization_code");
+		if (api->use_pkce) {
+			g_string_append_printf(req_body, "&code_verifier=%s",code_verifier);
+			free(code_verifier);
+		}
+	} else {
+		g_string_append(req_body, "&grant_type=refresh_token");
+		g_string_append_printf(req_body, "&refresh_token=%s", data.refresh_token);
+		free(data.refresh_token);
 	}
-	g_string_append(req_body, "&grant_type=authorization_code");
 	if (api->client_secret) {
 		tmp = curl_easy_escape(curl, api->client_secret, 0);
 		g_string_append_printf(req_body, "&client_secret=%s", tmp);
@@ -566,32 +862,40 @@ int main(int argc, char *argv[])
 	}
 
 	body = http_post(api->token_uri, req_body->str, &header);
-	if (!header && !body) {
-		g_warning("could not get token");
+	if (!header || !body) {
+		g_warning("could not get token, header or body is null");
+		exit (-1);
 	}
-	if (header) {
-		debug_print("token response header:\n%s\n", header);
-		g_free(header);
-	}
-	if (body) {
-		debug_print("token response body:\n%s\n\n", body);
-		parse_token_response(body, &data);
-		if (data.access_token) {
-			fputs(data.access_token, stdout);
-			fputs("\n", stdout);
-		}
-		if (data.refresh_token) {
-			fputs(data.refresh_token, stdout);
-			fputs("\n", stdout);
-		}
-		g_free(body);
-	}
+
+	debug_print("token response header:\n%s\n", header);
+	g_free(header);
 	g_string_free(req_body, TRUE);
-	g_free(code);
-	g_free(state);
 
 	curl_easy_cleanup(curl);
 	curl_global_cleanup();
 
+	if (api->auth_uri) g_free(api->auth_uri);
+	if (api->token_uri) g_free(api->token_uri);
+	if (api->redirect_uri) g_free(api->redirect_uri);
+	if (api->client_id) g_free(api->client_id);
+	if (api->client_secret) g_free(api->client_secret);
+	if (api->scope) g_free(api->scope);
+	g_free(api);
+
+	//debug_print("token response body:\n%s\n\n", body); //contains refresh token, do not uncomment and show this output to anyone else.
+	debug_print("token response body %lu bytes\n", strlen(body));
+	if (parse_token_response(body, &data) != 0){
+		fprintf(stderr, "Failed to parse body from server\n");
+		//fprintf(stderr, "raw response from server (do not show this to anyone as it may grant access to your email): \n%s\n\n", body);
+		exit (-1);
+	}
+	g_free(body);
+
+	save_creds_to_storage(&data);
+	gpgme_release(gpg_globals.gpg_ctx);
+
+	//output it.
+	printf ("%s\n%lu\n", data.access_token, (uint64_t)data.expires_at);
+	free(data.access_token);
 	return ret;
 }


### PR DESCRIPTION
I've added support for refreshing Oauth2.0 tokens, I've tested this with MS O365 (both a work and personal account) and Fastmail.  

I made this depend on gpg so it can encrypt the tokens stored on disk (because if I understand, the entire point of Oauth2.0 is to avoid using passwords, and having a plain text token on disk would defeat the point).  So if you want to use this, and don't already have a gpg key with a secret, you'll need to create one.  

I'd recommend this gpg-agent config:

default-cache-ttl 7300
max-cache-ttl 31536000

This way you need to enter the passphrase once per reboot / restart of gpg-agent, and as the token gets refreshed every hour or 2 (depending on its expiry), you won't need to re-enter your gpg passphrase again.

Mutt's implementation is similar, it uses a helper program that uses gpg to store the tokens.

Secondly this PR also adds support for PKCE which Fastmail requires when using Oauth 2.0.

Thirdly this PR includes a fix for doing the Oauth2.0 flow with Chromium.

I've only tested this on Linux (Ubuntu 20.04 and Gentoo), not Windows.

This probably conflicts with other PRs here...